### PR TITLE
Global Exception & Response 도입 그에 따른 User 도메인 swagger 고도화

### DIFF
--- a/src/main/java/org/clubs/blueheart/activity/api/ActivityApi.java
+++ b/src/main/java/org/clubs/blueheart/activity/api/ActivityApi.java
@@ -1,0 +1,66 @@
+//package org.clubs.blueheart.activity.api;
+//
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.media.Content;
+//import io.swagger.v3.oas.annotations.media.Schema;
+//import io.swagger.v3.oas.annotations.responses.ApiResponse;
+//import io.swagger.v3.oas.annotations.responses.ApiResponses;
+//import jakarta.validation.Valid;
+//import org.clubs.blueheart.activity.application.ActivityService;
+//import org.clubs.blueheart.activity.domain.ActivityStatus;
+//import org.clubs.blueheart.activity.dto.*;
+//import org.clubs.blueheart.exception.CustomExceptionStatus;
+//import org.clubs.blueheart.response.GlobalResponseHandler;
+//import org.clubs.blueheart.response.ResponseStatus;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.*;
+//
+//import java.util.List;
+//
+//@RestController
+//@RequestMapping("/api/v1/activity")
+//public class ActivityApi {
+//
+//    private final ActivityService activityService;
+//
+//    public ActivityApi(ActivityService activityService) {
+//        this.activityService = activityService;
+//    }
+//
+//    @PostMapping("/create")
+//    public ResponseEntity<GlobalResponseHandler<Void>> createActivity(@RequestBody @Valid ActivityCreateDto activityCreateDto) {
+//        activityService.createActivity(activityCreateDto);
+//        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_CREATED);
+//    }
+//
+//    @PutMapping("/update")
+//    public ResponseEntity<GlobalResponseHandler<Void>> updateActivity(@RequestBody @Valid ActivityUpdateDto activityUpdateDto) {
+//        activityService.updateActivityById(activityUpdateDto);
+//        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_UPDATED);
+//    }
+//
+//    @GetMapping("/{status}")
+//    public ResponseEntity<GlobalResponseHandler<List<ActivitySearchDto>>> findActivityByStatus(@PathVariable ActivityStatus status) {
+//        List<ActivitySearchDto> activities = activityService.findActivityByStatus(status);
+//        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_SEARCHED, activities);
+//    }
+//
+//    //TODO: 페이지네이션 구현 알아보기
+//    @GetMapping("/all")
+//    public ResponseEntity<GlobalResponseHandler<List<ActivitySearchDto>>> findAllActivity() {
+//        List<ActivitySearchDto> activities = activityService.findAllActivity();
+//        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_SEARCHED, activities);
+//    }
+//
+//    @GetMapping("/detail/{id}")
+//    public ResponseEntity<GlobalResponseHandler<List<ActivitySearchDto>>> findOneActivityDetailById(@PathVariable Long id) {
+//        List<ActivitySearchDto> activities = activityService.findOneActivityDetailById(id);
+//        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_SEARCHED, activities);
+//    }
+//
+//    @DeleteMapping("/delete")
+//    public ResponseEntity<GlobalResponseHandler<Void>> deleteUser(@RequestBody @Valid ActivityDeleteDto activityDeleteDto) {
+//        activityService.deleteActivity(activityDeleteDto);
+//        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_DELETED);
+//    }
+//}

--- a/src/main/java/org/clubs/blueheart/activity/api/ActivityHistoryApi.java
+++ b/src/main/java/org/clubs/blueheart/activity/api/ActivityHistoryApi.java
@@ -1,0 +1,41 @@
+//package org.clubs.blueheart.activity.api;
+//
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.media.Content;
+//import io.swagger.v3.oas.annotations.media.Schema;
+//import io.swagger.v3.oas.annotations.responses.ApiResponse;
+//import io.swagger.v3.oas.annotations.responses.ApiResponses;
+//import jakarta.validation.Valid;
+//import org.clubs.blueheart.activity.application.ActivityHistoryService;
+//import org.clubs.blueheart.activity.domain.ActivityStatus;
+//import org.clubs.blueheart.activity.dto.*;
+//import org.clubs.blueheart.exception.CustomExceptionStatus;
+//import org.clubs.blueheart.response.GlobalResponseHandler;
+//import org.clubs.blueheart.response.ResponseStatus;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.*;
+//
+//import java.util.List;
+//
+//@RestController
+//@RequestMapping("/api/v1/activity-history")
+//public class ActivityHistoryApi {
+//
+//    private final ActivityHistoryService activityHistoryService;
+//
+//    public ActivityHistoryApi(ActivityHistoryService activityHistoryService) {
+//        this.activityHistoryService = activityHistoryService;
+//    }
+//
+//    @PostMapping("/subscribe")
+//    public ResponseEntity<GlobalResponseHandler<Void>> subscribeActivity(@RequestBody @Valid ActivitySubscribeDto activitySubscribeDto) {
+//        activityHistoryService.subscribeActivity(activitySubscribeDto);
+//        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_SUBSCRIBED);
+//    }
+//
+//    @PostMapping("/unsubscribe")
+//    public ResponseEntity<GlobalResponseHandler<Void>> unsubscribeActivity(@RequestBody @Valid ActivitySubscribeDto activitySubscribeDto) {
+//        activityHistoryService.unsubscribeActivity(activitySubscribeDto);
+//        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_UNSUBSCRIBED);
+//    }
+//}

--- a/src/main/java/org/clubs/blueheart/activity/application/ActivityHistoryService.java
+++ b/src/main/java/org/clubs/blueheart/activity/application/ActivityHistoryService.java
@@ -1,0 +1,24 @@
+//package org.clubs.blueheart.activity.application;
+//
+//import org.clubs.blueheart.activity.dao.ActivityRepository;
+//import org.clubs.blueheart.activity.dto.ActivitySubscribeDto;
+//import org.springframework.stereotype.Service;
+//
+//@Service
+//public class ActivityHistoryService {
+//    public void subscribeActivity(ActivitySubscribeDto activitySubscribeDto) {
+//    }
+//
+//    public void unsubscribeActivity(ActivitySubscribeDto activitySubscribeDto) {
+//    }
+//
+////    private final ActivityHistoryRepository activityHistoryRepository;
+////
+////    public ActivityHistoryService(ActivityHistoryRepository activityHistoryRepository) {
+////        this.activityHistoryRepository = activityHistoryRepository;
+////    }
+//
+//
+//
+//
+//}

--- a/src/main/java/org/clubs/blueheart/activity/application/ActivityService.java
+++ b/src/main/java/org/clubs/blueheart/activity/application/ActivityService.java
@@ -1,0 +1,45 @@
+//package org.clubs.blueheart.activity.application;
+//
+//import org.clubs.blueheart.activity.dao.ActivityRepository;
+//import org.clubs.blueheart.activity.domain.ActivityStatus;
+//import org.clubs.blueheart.activity.dto.ActivityCreateDto;
+//import org.clubs.blueheart.activity.dto.ActivityDeleteDto;
+//import org.clubs.blueheart.activity.dto.ActivitySearchDto;
+//import org.clubs.blueheart.activity.dto.ActivityUpdateDto;
+//import org.clubs.blueheart.user.dao.UserRepository;
+//import org.clubs.blueheart.user.dto.UserDeleteDto;
+//import org.clubs.blueheart.user.dto.UserInfoDto;
+//import org.clubs.blueheart.user.dto.UserUpdateDto;
+//import org.springframework.stereotype.Service;
+//
+//import java.util.List;
+//
+//import static org.clubs.blueheart.user.util.UserValidationUtil.isInteger;
+//
+//
+//@Service
+//public class ActivityService {
+//
+////    private final ActivityRepository activityRepository;
+////
+////    public ActivityService(ActivityRepository activityRepository) {
+////        this.activityRepository = activityRepository;
+////    }
+//
+//
+//    public void updateActivityById(ActivityUpdateDto activityUpdateDto) {}
+//
+//    public List<ActivitySearchDto> findActivityByStatus(ActivityStatus status) {}
+//
+//    public List<ActivitySearchDto> findAllActivity() {}
+//
+//    public List<ActivitySearchDto> findOneActivityDetailById(Long id) {}
+//
+//    public void deleteActivity(ActivityDeleteDto activityDeleteDto) {
+//    }
+//
+//    public void createActivity(ActivityCreateDto activityCreateDto) {
+//
+//    }
+//}
+//

--- a/src/main/java/org/clubs/blueheart/activity/dao/ActivityCustomDao.java
+++ b/src/main/java/org/clubs/blueheart/activity/dao/ActivityCustomDao.java
@@ -1,0 +1,6 @@
+package org.clubs.blueheart.activity.dao;
+
+public interface ActivityCustomDao {
+    // 커스텀 메서드 선언
+    void someCustomMethod();
+}

--- a/src/main/java/org/clubs/blueheart/activity/dao/ActivityCustomDaoImpl.java
+++ b/src/main/java/org/clubs/blueheart/activity/dao/ActivityCustomDaoImpl.java
@@ -1,0 +1,11 @@
+package org.clubs.blueheart.activity.dao;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ActivityCustomDaoImpl implements ActivityCustomDao {
+    @Override
+    public void someCustomMethod() {
+        // 구현 로직
+    }
+}

--- a/src/main/java/org/clubs/blueheart/activity/dao/ActivityDao.java
+++ b/src/main/java/org/clubs/blueheart/activity/dao/ActivityDao.java
@@ -1,0 +1,8 @@
+package org.clubs.blueheart.activity.dao;
+
+import org.clubs.blueheart.activity.domain.Activity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface ActivityDao extends ActivityCustomDao, JpaRepository<Activity, Long> {
+}

--- a/src/main/java/org/clubs/blueheart/activity/dao/ActivityRepository.java
+++ b/src/main/java/org/clubs/blueheart/activity/dao/ActivityRepository.java
@@ -1,0 +1,4 @@
+package org.clubs.blueheart.activity.dao;
+
+public interface ActivityRepository {
+}

--- a/src/main/java/org/clubs/blueheart/activity/dao/ActivityRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/activity/dao/ActivityRepositoryImpl.java
@@ -1,0 +1,7 @@
+package org.clubs.blueheart.activity.dao;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ActivityRepositoryImpl {
+}

--- a/src/main/java/org/clubs/blueheart/activity/domain/Activity.java
+++ b/src/main/java/org/clubs/blueheart/activity/domain/Activity.java
@@ -19,44 +19,6 @@ import org.springframework.data.annotation.LastModifiedDate;
 @Log4j2
 public class Activity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @NotNull
-    @ManyToOne(optional = false)
-    @JoinColumn(name="creatorId", nullable = false)
-    private User creator_id;
-
-    @Enumerated(EnumType.STRING)
-    private ActivityStatus status;
-
-    @Column(name="max_number")
-    private Integer maxNumber;
-
-    @NotNull
-    @Column(nullable = false, length = 255)
-    private String description;
-
-    @NotNull
-    @Column(nullable = false, length = 255)
-    private String place;
-
-    @NotNull
-    @Column(name="place_url", nullable = false, length = 255)
-    private String placeUrl;
-
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private OffsetDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updatedAt", nullable = false)
-    private OffsetDateTime updatedAt;
-
-    @Column(name = "deleted_at")
-    private OffsetDateTime deletedAt;
-
     // ManyToMany 관계 설정
     @ManyToMany
     @JoinTable(
@@ -64,7 +26,35 @@ public class Activity {
             joinColumns = @JoinColumn(name = "activity_id"),   // groups 테이블 FK
             inverseJoinColumns = @JoinColumn(name = "user_id") // users 테이블 FK
     )
-    private java.util.Set<User> users = new java.util.HashSet<>();
+    private final java.util.Set<User> users = new java.util.HashSet<>();
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotNull
+    @ManyToOne(optional = false)
+    @JoinColumn(name="creatorId", nullable = false)
+    private User creator_id;
+    @Enumerated(EnumType.STRING)
+    private ActivityStatus status;
+    @Column(name="max_number")
+    private Integer maxNumber;
+    @NotNull
+    @Column(nullable = false, length = 255)
+    private String description;
+    @NotNull
+    @Column(nullable = false, length = 255)
+    private String place;
+    @NotNull
+    @Column(name="place_url", nullable = false, length = 255)
+    private String placeUrl;
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+    @LastModifiedDate
+    @Column(name = "updatedAt", nullable = false)
+    private OffsetDateTime updatedAt;
+    @Column(name = "deleted_at")
+    private OffsetDateTime deletedAt;
 
     @Builder
     public Activity(ActivityStatus status, Integer maxNumber, String description, String place, String placeUrl) {

--- a/src/main/java/org/clubs/blueheart/activity/domain/Activity.java
+++ b/src/main/java/org/clubs/blueheart/activity/domain/Activity.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 
 import org.clubs.blueheart.user.domain.User;
@@ -30,31 +31,45 @@ public class Activity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @NotNull
     @ManyToOne(optional = false)
-    @JoinColumn(name="creatorId", nullable = false)
-    private User creator_id;
+    @JoinColumn(name="creator_id", nullable = false)
+    private User creatorId;
+
+    @NotNull
+    @Column(nullable = false, length = 15)
+    private String title;
+
     @Enumerated(EnumType.STRING)
     private ActivityStatus status;
+
     @Column(name="max_number")
     private Integer maxNumber;
+
     @NotNull
     @Column(nullable = false, length = 255)
     private String description;
+
     @NotNull
     @Column(nullable = false, length = 255)
     private String place;
+
     @NotNull
     @Column(name="place_url", nullable = false, length = 255)
     private String placeUrl;
+
+    @NotNull
+    @Column(name = "expired_at", nullable = false)
+    private LocalDateTime expiredAt;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
-    private OffsetDateTime createdAt;
-    @LastModifiedDate
-    @Column(name = "updatedAt", nullable = false)
-    private OffsetDateTime updatedAt;
+    private LocalDateTime createdAt;
+
+
     @Column(name = "deleted_at")
-    private OffsetDateTime deletedAt;
+    private LocalDateTime deletedAt;
 
     @Builder
     public Activity(ActivityStatus status, Integer maxNumber, String description, String place, String placeUrl) {

--- a/src/main/java/org/clubs/blueheart/activity/domain/ActivityHistory.java
+++ b/src/main/java/org/clubs/blueheart/activity/domain/ActivityHistory.java
@@ -1,0 +1,45 @@
+package org.clubs.blueheart.activity.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.clubs.blueheart.user.domain.User;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "activity_histories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ActivityHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "activity_id", nullable = false)
+    private Activity activity;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+
+    @Builder
+    public ActivityHistory(Activity activity, User user) {
+        this.activity = activity;
+        this.user = user;
+    }
+}

--- a/src/main/java/org/clubs/blueheart/activity/dto/ActivityCreateDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/ActivityCreateDto.java
@@ -1,0 +1,23 @@
+package org.clubs.blueheart.activity.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ActivityCreateDto {
+
+    @NotBlank(message = "MaxNumber must not be blank")
+    private Integer maxNumber;
+
+    @NotNull(message = "Description must not be null")
+    private String description;
+
+    @NotNull(message = "Place must not be null")
+    private String place;
+
+    @NotNull(message = "PlaceUrl must not be null")
+    private String placeUrl;
+}

--- a/src/main/java/org/clubs/blueheart/activity/dto/ActivityDeleteDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/ActivityDeleteDto.java
@@ -1,0 +1,11 @@
+package org.clubs.blueheart.activity.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ActivityDeleteDto {
+
+    private Long id;
+}

--- a/src/main/java/org/clubs/blueheart/activity/dto/ActivityDetailDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/ActivityDetailDto.java
@@ -1,0 +1,22 @@
+package org.clubs.blueheart.activity.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+import org.clubs.blueheart.activity.domain.ActivityStatus;
+
+import java.time.LocalDateTime;
+
+@Data
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+public class ActivityDetailDto extends ActivitySearchDto {
+
+    private String place;
+
+    private String placeUrl;
+
+}

--- a/src/main/java/org/clubs/blueheart/activity/dto/ActivitySearchDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/ActivitySearchDto.java
@@ -1,0 +1,36 @@
+package org.clubs.blueheart.activity.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
+import org.clubs.blueheart.activity.domain.ActivityStatus;
+
+import java.time.LocalDateTime;
+
+@Data
+@SuperBuilder
+public class ActivitySearchDto {
+
+    private Long id;
+
+    @NotNull(message = "Title must not be null")
+    private String title;
+
+    @NotNull(message = "Description must not be null")
+    private String description;
+
+    private ActivityStatus status;
+
+    private Boolean isSubscribed;
+
+    @NotBlank(message = "CurrentNumber must not be blank")
+    private Integer currentNumber;
+
+    @NotBlank(message = "MaxNumber must not be blank")
+    private Integer maxNumber;
+
+    private LocalDateTime expiredAt;
+
+}

--- a/src/main/java/org/clubs/blueheart/activity/dto/ActivitySubscribeDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/ActivitySubscribeDto.java
@@ -1,0 +1,11 @@
+package org.clubs.blueheart.activity.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class ActivitySubscribeDto {
+
+    private Long id;
+}

--- a/src/main/java/org/clubs/blueheart/activity/dto/ActivityUpdateDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/ActivityUpdateDto.java
@@ -1,0 +1,28 @@
+package org.clubs.blueheart.activity.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Data;
+import org.clubs.blueheart.activity.domain.ActivityStatus;
+
+@Data
+@Builder
+public class ActivityUpdateDto {
+
+    private Long id;
+
+    private ActivityStatus status;
+
+    @NotBlank(message = "MaxNumber must not be blank")
+    private Integer maxNumber;
+
+    @NotNull(message = "Description must not be null")
+    private String description;
+
+    @NotNull(message = "Place must not be null")
+    private String place;
+
+    @NotNull(message = "PlaceUrl must not be null")
+    private String placeUrl;
+}

--- a/src/main/java/org/clubs/blueheart/exception/ApiException.java
+++ b/src/main/java/org/clubs/blueheart/exception/ApiException.java
@@ -1,0 +1,22 @@
+package org.clubs.blueheart.exception;
+
+public class ApiException extends RuntimeException implements BaseException {
+
+    private final ExceptionStatus status;
+
+    /**
+     * @param status exception에 대한 정보에 대한 enum
+     */
+    public ApiException(ExceptionStatus status) {
+        this.status = status;
+    }
+
+    public ExceptionStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return status.getMessage();
+    }
+}

--- a/src/main/java/org/clubs/blueheart/exception/ApplicationException.java
+++ b/src/main/java/org/clubs/blueheart/exception/ApplicationException.java
@@ -1,0 +1,22 @@
+package org.clubs.blueheart.exception;
+
+public class ApplicationException extends RuntimeException implements BaseException {
+
+    private final ExceptionStatus status;
+
+    /**
+     * @param status exception에 대한 정보에 대한 enum
+     */
+    public ApplicationException(ExceptionStatus status) {
+        this.status = status;
+    }
+
+    public ExceptionStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return status.getMessage();
+    }
+}

--- a/src/main/java/org/clubs/blueheart/exception/BaseException.java
+++ b/src/main/java/org/clubs/blueheart/exception/BaseException.java
@@ -1,0 +1,4 @@
+package org.clubs.blueheart.exception;
+
+public interface BaseException {
+}

--- a/src/main/java/org/clubs/blueheart/exception/CustomExceptionStatus.java
+++ b/src/main/java/org/clubs/blueheart/exception/CustomExceptionStatus.java
@@ -1,0 +1,29 @@
+package org.clubs.blueheart.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@RequiredArgsConstructor
+@Getter
+public class CustomExceptionStatus {
+
+    private final int statusCode;
+    private final String message;
+    private final String error;
+
+    public CustomExceptionStatus(HttpStatus status, String message) {
+        this.statusCode = status.value();
+        this.message = message;
+        this.error = status.getReasonPhrase();
+    }
+
+    public CustomExceptionStatus(ExceptionStatus status, String message) {
+        this.statusCode = status.getStatusCode();
+        this.message = status.getMessage() + "\n해제 날짜 : " + message;
+        this.error = status.getError();
+    }
+}

--- a/src/main/java/org/clubs/blueheart/exception/DaoException.java
+++ b/src/main/java/org/clubs/blueheart/exception/DaoException.java
@@ -1,0 +1,22 @@
+package org.clubs.blueheart.exception;
+
+public class DaoException extends RuntimeException implements BaseException {
+
+    private final ExceptionStatus status;
+
+    /**
+     * @param status exception에 대한 정보에 대한 enum
+     */
+    public DaoException(ExceptionStatus status) {
+        this.status = status;
+    }
+
+    public ExceptionStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return status.getMessage();
+    }
+}

--- a/src/main/java/org/clubs/blueheart/exception/DomainException.java
+++ b/src/main/java/org/clubs/blueheart/exception/DomainException.java
@@ -1,0 +1,22 @@
+package org.clubs.blueheart.exception;
+
+public class DomainException extends RuntimeException implements BaseException {
+
+    private final ExceptionStatus status;
+
+    /**
+     * @param status exception에 대한 정보에 대한 enum
+     */
+    public DomainException(ExceptionStatus status) {
+        this.status = status;
+    }
+
+    public ExceptionStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return status.getMessage();
+    }
+}

--- a/src/main/java/org/clubs/blueheart/exception/DtoException.java
+++ b/src/main/java/org/clubs/blueheart/exception/DtoException.java
@@ -1,0 +1,22 @@
+package org.clubs.blueheart.exception;
+
+public class DtoException extends RuntimeException implements BaseException {
+
+    private final ExceptionStatus status;
+
+    /**
+     * @param status exception에 대한 정보에 대한 enum
+     */
+    public DtoException(ExceptionStatus status) {
+        this.status = status;
+    }
+
+    public ExceptionStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return status.getMessage();
+    }
+}

--- a/src/main/java/org/clubs/blueheart/exception/ExceptionStatus.java
+++ b/src/main/java/org/clubs/blueheart/exception/ExceptionStatus.java
@@ -1,0 +1,132 @@
+package org.clubs.blueheart.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@RequiredArgsConstructor
+@Getter
+public enum ExceptionStatus {
+
+    // USER ERROR CODE
+    NOT_FOUND_ADMIN(HttpStatus.NOT_FOUND, "어드민이 존재하지 않습니다"),
+    NOT_FOUND_STAFF(HttpStatus.NOT_FOUND, "스태프가 존재하지 않습니다"),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다");
+
+    //    NOT_FOUND_LENT_HISTORY(HttpStatus.NOT_FOUND, "대여한 사물함이 존재하지 않습니다."),
+//    NOT_FOUND_CLUB(HttpStatus.NOT_FOUND, "동아리가 존재하지 않습니다."),
+//    NOT_FOUND_ITEM(HttpStatus.NOT_FOUND, "아이템이 존재하지 않습니다"),
+//    LENT_CLUB(HttpStatus.I_AM_A_TEAPOT, "동아리 전용 사물함입니다"),
+//    LENT_NOT_CLUB(HttpStatus.I_AM_A_TEAPOT, "동아리 전용 사물함이 아닙니다"),
+//    LENT_EXPIRE_IMMINENT(HttpStatus.I_AM_A_TEAPOT, "만료가 임박한 공유 사물함입니다\n해당 사물함은 대여할 수 없습니다"),
+//    LENT_FULL(HttpStatus.CONFLICT, "사물함에 잔여 자리가 없습니다"),
+//    LENT_EXPIRED(HttpStatus.FORBIDDEN, "연체된 사물함은 대여할 수 없습니다"),
+//    LENT_BROKEN(HttpStatus.FORBIDDEN, "고장난 사물함은 대여할 수 없습니다"),
+//    NO_LENT_CABINET(HttpStatus.FORBIDDEN, "대여한 사물함이 없습니다"),
+//    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러가 발생했습니다"),
+//    OAUTH_BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "인증 서버와 통신 중 에러가 발생했습니다"),
+//    SLACK_BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "슬랙 서버와 통신 중 에러가 발생했습니다"),
+//    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인 정보가 유효하지 않습니다\n다시 로그인해주세요"),
+//    UNCHANGEABLE_CABINET(HttpStatus.BAD_REQUEST, "사물함의 상태를 변경할 수 없습니다."),
+//    LENT_ALREADY_EXISTED(HttpStatus.BAD_REQUEST, "이미 대여중인 사물함이 있습니다"),
+//    USER_ALREADY_EXISTED(HttpStatus.BAD_REQUEST, "이미 존재하는 유저입니다"),
+//    ADMIN_ALREADY_EXISTED(HttpStatus.BAD_REQUEST, "이미 존재하는 어드민입니다"),
+//    COIN_COLLECTION_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "오늘은 이미 동전줍기를 수행했습니다."),
+//    NOT_CLUB_USER(HttpStatus.BAD_REQUEST, "동아리 유저가 아닙니다"),
+//    INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "유효하지 않은 입력입니다"),
+//    INVALID_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 상태변경입니다"),
+//    JSON_PROCESSING_EXCEPTION(HttpStatus.BAD_REQUEST, "JSON 파싱 중 에러가 발생했습니다"),
+//    SHARE_CODE_TRIAL_EXCEEDED(HttpStatus.BAD_REQUEST, "초대 코드 입력 오류 초과로 입장이 제한된 상태입니다."),
+//    INVALID_EXPIRED_AT(HttpStatus.BAD_REQUEST, "잘못된 만료일 입니다"),
+//    INCORRECT_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다"),
+//    ALL_BANNED_USER(HttpStatus.BAD_REQUEST, "ALL 밴 상태의 유저입니다."),
+//    SHARE_BANNED_USER(HttpStatus.BAD_REQUEST, "초대코드를 3회 이상 틀린 유저입니다."),
+//    LENT_PENDING(HttpStatus.BAD_REQUEST, "오픈 예정인 사물함입니다."),
+//    WRONG_SHARE_CODE(HttpStatus.BAD_REQUEST, "초대코드가 유효하지 않습니다."),
+//    NOT_FOUND_BAN_HISTORY(HttpStatus.NOT_FOUND, "현재 정지 상태인 유저가 아닙니다."),
+//    BLACKHOLED_USER(HttpStatus.BAD_REQUEST, "블랙홀 상태의 유저입니다."),
+//    BLACKHOLE_REFRESHING(HttpStatus.BAD_REQUEST, "블랙홀 갱신 중 입니다.\n잠시 후에 다시 시도해주세요."),
+//    UNAUTHORIZED_ADMIN(HttpStatus.UNAUTHORIZED, "관리자 로그인 정보가 유효하지 않습니다\n다시 로그인해주세요"),
+//    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "사용자 로그인 정보가 유효하지 않습니다\n다시 로그인해주세요"),
+//    EXTERNAL_API_EXCEPTION(HttpStatus.BAD_REQUEST, "외부 API와 통신 중 에러가 발생했습니다"),
+//    EXISTED_CLUB_USER(HttpStatus.CONFLICT, "이미 존재하는 동아리 유저입니다"),
+//    CLUB_HAS_LENT_CABINET(HttpStatus.NOT_ACCEPTABLE, "대여 중인 사물함을 반납 후 삭제할 수 있습니다."),
+//    HANEAPI_ERROR(HttpStatus.BAD_GATEWAY, "24HANE API 통신에 에러가 있습니다."),
+//    EXTENSION_NOT_FOUND(HttpStatus.BAD_REQUEST, "연장권이 존재하지 않습니다."),
+//    EXTENSION_LENT_DELAYED(HttpStatus.FORBIDDEN, "연장권은 연체된 사물함에 사용할 수 없습니다."),
+//    EXTENSION_SOLO_IN_SHARE_NOT_ALLOWED(HttpStatus.UNAUTHORIZED, "연장권은 1명일 때 사용할 수 없습니다."),
+//    MAIL_BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "메일 전송 중 에러가 발생했습니다"),
+//    SLACK_REQUEST_BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "슬랙 인증 중 에러가 발생했습니다."),
+//    SLACK_MESSAGE_SEND_BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "슬랙 메세지 전송 중 에러가 발생했습니다."),
+//    SLACK_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "슬랙 아이디를 찾을 수 없습니다."),
+//    NOT_FOUND_ALARM(HttpStatus.BAD_REQUEST, "알람이 존재하지 않습니다"),
+//    INVALID_LENT_TYPE(HttpStatus.BAD_REQUEST, "사물함의 대여 타입이 유효하지 않습니다."),
+//    NOT_FOUND_BUILDING(HttpStatus.NOT_FOUND, "빌딩이 존재하지 않습니다."),
+//    SWAP_EXPIRE_IMMINENT(HttpStatus.I_AM_A_TEAPOT, "현재 사물함의 대여 기간의 만료가 임박해 사물함을 이동 할 수 없습니다."),
+//    SWAP_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "이사하기 기능을 사용한 기록이 없습니다."),
+//    SWAP_SAME_CABINET(HttpStatus.BAD_REQUEST, "같은 사물함으로 이사할 수 없습니다."),
+//    SWAP_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "이사하기 기능을 이미 사용했습니다."),
+//    INVALID_CLUB(HttpStatus.BAD_REQUEST, "동아리가 맞지 않습니다."),
+//    NOT_CLUB_MASTER(HttpStatus.BAD_REQUEST, "동아리 장이 아닙니다."),
+//    INVALID_CLUB_MASTER(HttpStatus.BAD_REQUEST, "동아리에 동아리 장이 없습니다."),
+//    NOT_FOUND_CLUB_LENT_HISTORY(HttpStatus.NOT_FOUND, "동아리가 대여한 사물함이 없습니다."),
+//    INVALID_PRESENTATION_CATEGORY(HttpStatus.BAD_REQUEST, "발표회에 정의된 카테고리가 아닙니다."),
+//    INVALID_PRESENTATION_DATE(HttpStatus.BAD_REQUEST, "가능한 발표 날짜가 아닙니다"),
+//    INVALID_DATE(HttpStatus.BAD_REQUEST, "잘못된 날짜입니다."),
+//    PRESENTATION_ALREADY_EXISTED(HttpStatus.CONFLICT, "이미 예약된 발표 날짜입니다"),
+//    NOT_FOUND_FORM(HttpStatus.NOT_FOUND, "신청서가 존재하지 않습니다."),
+//    INVALID_FORM_ID(HttpStatus.BAD_REQUEST, "잘못된 신청번호입니다."),
+//    INVALID_LOCATION(HttpStatus.BAD_REQUEST, "잘못된 장소입니다."),
+//    INVALID_ITEM_USE_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 아이템 사용 요청입니다."),
+//    ITEM_NOT_ON_SALE(HttpStatus.BAD_REQUEST, "구매할 수 없는 아이템입니다."),
+//    NOT_ENOUGH_COIN(HttpStatus.BAD_REQUEST, "보유한 코인이 아이템 가격보다 적습니다."),
+//    INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "토큰이 없거나, 유효하지 않은 JWT 토큰입니다."),
+//    NOT_FOUND_SECTION(HttpStatus.BAD_REQUEST, "사물함 구역 정보를 찾을 수 없습니다."),
+//    ITEM_NOT_OWNED(HttpStatus.BAD_REQUEST, "해당 아이템을 보유하고 있지 않습니다"),
+//    ITEM_USE_DUPLICATED(HttpStatus.FORBIDDEN, "아이템이 중복 사용되었습니다."),
+//    INVALID_AMOUNT(HttpStatus.BAD_REQUEST, "코인 지급양은 비어있을 수 없습니다.");
+
+    // 필드 선언은 열거형 상수 뒤에 위치
+    private final int statusCode;
+    private final String message;
+    private final String error;
+
+    // 생성자도 열거형 상수 뒤에 위치
+    ExceptionStatus(HttpStatus status, String message) {
+        this.statusCode = status.value();
+        this.message = message;
+        this.error = status.getReasonPhrase();
+    }
+
+    // 메서드들
+    public ApiException asApiException() {
+        return new ApiException(this);
+    }
+
+    public ApplicationException asApplicationException() {
+        return new ApplicationException(this);
+    }
+
+    public DaoException asDaoException() {
+        return new DaoException(this);
+    }
+
+    public DtoException asDtoException() {
+        return new DtoException(this);
+    }
+
+    public DomainException asDomainException() {
+        return new DomainException(this);
+    }
+
+    public RepositoryException asRepositoryException() {
+        return new RepositoryException(this);
+    }
+
+    public UtilException asUtilException() {
+        return new UtilException(this);
+    }
+}
+

--- a/src/main/java/org/clubs/blueheart/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/clubs/blueheart/exception/GlobalExceptionHandler.java
@@ -1,0 +1,91 @@
+package org.clubs.blueheart.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    /**
+     * Handle ApiException
+     */
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<CustomExceptionStatus> handleApiException(ApiException ex, WebRequest request) {
+        return buildErrorResponse(ex.getStatus(), request);
+    }
+
+    /**
+     * Handle ApplicationException
+     */
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<CustomExceptionStatus> handleApplicationException(ApplicationException ex, WebRequest request) {
+        return buildErrorResponse(ex.getStatus(), request);
+    }
+
+    /**
+     * Handle DaoException
+     */
+    @ExceptionHandler(DaoException.class)
+    public ResponseEntity<CustomExceptionStatus> handleDaoException(DaoException ex, WebRequest request) {
+        return buildErrorResponse(ex.getStatus(), request);
+
+    }/**
+     * Handle DtoException
+     */
+    @ExceptionHandler(DtoException.class)
+    public ResponseEntity<CustomExceptionStatus> handleDtoException(DtoException ex, WebRequest request) {
+        return buildErrorResponse(ex.getStatus(), request);
+    }
+
+    /**
+     * Handle DomainException
+     */
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<CustomExceptionStatus> handleDomainException(DomainException ex, WebRequest request) {
+        return buildErrorResponse(ex.getStatus(), request);
+    }
+
+    /**
+     * Handle RepositoryException
+     */
+    @ExceptionHandler(RepositoryException.class)
+    public ResponseEntity<CustomExceptionStatus> handleRepositoryException(RepositoryException ex, WebRequest request) {
+        return buildErrorResponse(ex.getStatus(), request);
+    }
+
+    /**
+     * Handle UtilException
+     */
+    @ExceptionHandler(UtilException.class)
+    public ResponseEntity<CustomExceptionStatus> handleUtilException(UtilException ex, WebRequest request) {
+        return buildErrorResponse(ex.getStatus(), request);
+    }
+
+    /**
+     * Handle Generic Exceptions
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CustomExceptionStatus> handleGenericException(Exception ex, WebRequest request) {
+        CustomExceptionStatus errorResponse = new CustomExceptionStatus(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                ex.getMessage()
+        );
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+
+    /**
+     * Build the error response
+     */
+    private ResponseEntity<CustomExceptionStatus> buildErrorResponse(ExceptionStatus errorCode, WebRequest request) {
+        CustomExceptionStatus errorResponse = new CustomExceptionStatus(
+                errorCode.getStatusCode(),
+                errorCode.getMessage(),
+                errorCode.getError()
+        );
+        return ResponseEntity.status(errorCode.getStatusCode()).body(errorResponse);
+    }
+}

--- a/src/main/java/org/clubs/blueheart/exception/RepositoryException.java
+++ b/src/main/java/org/clubs/blueheart/exception/RepositoryException.java
@@ -1,0 +1,22 @@
+package org.clubs.blueheart.exception;
+
+public class RepositoryException extends RuntimeException implements BaseException {
+
+    private final ExceptionStatus status;
+
+    /**
+     * @param status exception에 대한 정보에 대한 enum
+     */
+    public RepositoryException(ExceptionStatus status) {
+        this.status = status;
+    }
+
+    public ExceptionStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return status.getMessage();
+    }
+}

--- a/src/main/java/org/clubs/blueheart/exception/UtilException.java
+++ b/src/main/java/org/clubs/blueheart/exception/UtilException.java
@@ -1,0 +1,22 @@
+package org.clubs.blueheart.exception;
+
+public class UtilException extends RuntimeException implements BaseException {
+
+    private final ExceptionStatus status;
+
+    /**
+     * @param status exception에 대한 정보에 대한 enum
+     */
+    public UtilException(ExceptionStatus status) {
+        this.status = status;
+    }
+
+    public ExceptionStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return status.getMessage();
+    }
+}

--- a/src/main/java/org/clubs/blueheart/group/domain/Group.java
+++ b/src/main/java/org/clubs/blueheart/group/domain/Group.java
@@ -19,25 +19,6 @@ import org.springframework.data.annotation.LastModifiedDate;
 @Log4j2
 public class Group {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @NotNull
-    @Column(nullable = false, length = 20)
-    private String name;
-
-    @CreatedDate
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private OffsetDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(name = "updatedAt", nullable = false)
-    private OffsetDateTime updatedAt;
-
-    @Column(name = "deleted_at")
-    private OffsetDateTime deletedAt;
-
     // ManyToMany 관계 설정
     @ManyToMany
     @JoinTable(
@@ -45,7 +26,21 @@ public class Group {
             joinColumns = @JoinColumn(name = "group_id"),   // groups 테이블 FK
             inverseJoinColumns = @JoinColumn(name = "user_id") // users 테이블 FK
     )
-    private java.util.Set<User> users = new java.util.HashSet<>();
+    private final java.util.Set<User> users = new java.util.HashSet<>();
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @NotNull
+    @Column(nullable = false, length = 20)
+    private String name;
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+    @LastModifiedDate
+    @Column(name = "updatedAt", nullable = false)
+    private OffsetDateTime updatedAt;
+    @Column(name = "deleted_at")
+    private OffsetDateTime deletedAt;
 
     @Builder
     public Group(String name) {

--- a/src/main/java/org/clubs/blueheart/response/GlobalResponseHandler.java
+++ b/src/main/java/org/clubs/blueheart/response/GlobalResponseHandler.java
@@ -1,0 +1,37 @@
+package org.clubs.blueheart.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@Builder
+public class GlobalResponseHandler<T> {
+    private int statusCode;
+    private String message;
+    private T data;
+
+    /**
+     * 성공 응답 생성 (데이터 포함)
+     */
+    public static <T> ResponseEntity<GlobalResponseHandler<T>> success(ResponseStatus status, T data) {
+        return ResponseEntity.status(status.getStatusCode())
+                .body(GlobalResponseHandler.<T>builder()
+                        .statusCode(status.getStatusCode())
+                        .message(status.getMessage())
+                        .data(data)
+                        .build());
+    }
+
+    /**
+     * 성공 응답 생성 (데이터 없이)
+     */
+    public static ResponseEntity<GlobalResponseHandler<Void>> success(ResponseStatus status) {
+        return ResponseEntity.status(status.getStatusCode())
+                .body(GlobalResponseHandler.<Void>builder()
+                        .statusCode(status.getStatusCode())
+                        .message(status.getMessage())
+                        .data(null)
+                        .build());
+    }
+}

--- a/src/main/java/org/clubs/blueheart/response/ResponseStatus.java
+++ b/src/main/java/org/clubs/blueheart/response/ResponseStatus.java
@@ -14,9 +14,16 @@ public enum ResponseStatus {
     USER_SEARCHED(HttpStatus.OK, "유저를 성공적으로 조회했습니다"),
     USER_CREATED(HttpStatus.CREATED, "유저가 성공적으로 생성되었습니다"),
     USER_DELETED(HttpStatus.OK, "유저가 성공적으로 삭제되었습니다"),
-    USER_UPDATED(HttpStatus.OK, "유저정보가 성공적으로 갱신되었습니다");
+    USER_UPDATED(HttpStatus.OK, "유저 정보가 성공적으로 갱신되었습니다"),
 
     // ACTIVITY RESPONSE CODE
+    ACTIVITY_CREATED(HttpStatus.CREATED, "액티비티가 성공적으로 생성되었습니다"),
+    ACTIVITY_UPDATED(HttpStatus.OK, "액티비티 정보가 성공적으로 갱신되었습니다"),
+    ACTIVITY_DELETED(HttpStatus.OK, "액티비티를 성공적으로 삭제했습니다"),
+    ACTIVITY_SEARCHED(HttpStatus.OK, "액티비티를 성공적으로 조회했습니다"),
+    ACTIVITY_SUBSCRIBED(HttpStatus.OK, "액티비티를 성공적으로 구독신청했습니다"),
+    ACTIVITY_UNSUBSCRIBED(HttpStatus.OK, "액티비티를 성공적으로 구독해지했습니다");
+
 
     // AUTH RESPONSE CODE
 

--- a/src/main/java/org/clubs/blueheart/response/ResponseStatus.java
+++ b/src/main/java/org/clubs/blueheart/response/ResponseStatus.java
@@ -1,0 +1,37 @@
+package org.clubs.blueheart.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@RequiredArgsConstructor
+@Getter
+public enum ResponseStatus {
+
+    // USER RESPONSE CODE
+    USER_SEARCHED(HttpStatus.OK, "유저를 성공적으로 조회했습니다"),
+    USER_CREATED(HttpStatus.CREATED, "유저가 성공적으로 생성되었습니다"),
+    USER_DELETED(HttpStatus.OK, "유저가 성공적으로 삭제되었습니다"),
+    USER_UPDATED(HttpStatus.OK, "유저정보가 성공적으로 갱신되었습니다");
+
+    // ACTIVITY RESPONSE CODE
+
+    // AUTH RESPONSE CODE
+
+    // GROUP RESPONSE CODE
+
+    // NOTIFICATION RESPONSE CODE
+
+
+    private final int statusCode;
+    private final String message;
+
+    ResponseStatus(HttpStatus status, String message) {
+        this.statusCode = status.value();
+        this.message = message;
+    }
+
+}
+

--- a/src/main/java/org/clubs/blueheart/user/api/UserApi.java
+++ b/src/main/java/org/clubs/blueheart/user/api/UserApi.java
@@ -41,9 +41,9 @@ public class UserApi {
             @Parameter(name = "role", description = "직책" , example = "USER")
     })
     @PostMapping("/create")
-    public ResponseEntity createUser(@RequestBody @Valid UserInfoDto userInfoDto) {
+    public ResponseEntity<HttpStatus> createUser(@RequestBody @Valid UserInfoDto userInfoDto) {
         userService.createUser(userInfoDto);
-        return new ResponseEntity(HttpStatus.OK);
+        return ResponseEntity.ok(HttpStatus.OK);
     }
 
     @Operation(summary = "사용자 검색", description = "사용자 정보를 검색하는 API, keyword 가 없을 시 모두 반환")
@@ -79,9 +79,9 @@ public class UserApi {
             @Parameter(name = "role", description = "사용자 역할", example = "USER")
     })
     @PutMapping("/update")
-    public ResponseEntity updateUser(@RequestBody @Valid UserUpdateDto userUpdateDto) {
+    public ResponseEntity<HttpStatus> updateUser(@RequestBody @Valid UserUpdateDto userUpdateDto) {
         userService.updateUserById(userUpdateDto);
-        return new ResponseEntity(HttpStatus.OK);
+        return ResponseEntity.ok(HttpStatus.OK);
     }
 
     @Operation(summary = "사용자 정보 삭제", description = "특정 사용자의 정보를 삭제 하는 API 입니다.(Soft Delete)")
@@ -95,8 +95,8 @@ public class UserApi {
                     example = "1"),
     })
     @DeleteMapping("/delete")
-    public ResponseEntity deleteUser(@RequestBody @Valid UserDeleteDto userDeleteDto) {
+    public ResponseEntity<HttpStatus> deleteUser(@RequestBody @Valid UserDeleteDto userDeleteDto) {
         userService.deleteUserById(userDeleteDto);
-        return new ResponseEntity(HttpStatus.OK);
+        return ResponseEntity.ok(HttpStatus.OK);
     }
 }

--- a/src/main/java/org/clubs/blueheart/user/api/UserApi.java
+++ b/src/main/java/org/clubs/blueheart/user/api/UserApi.java
@@ -63,40 +63,40 @@ public class UserApi {
         return ResponseEntity.status(HttpStatus.OK).body(userService.findUserByKeyword(keyword));
     }
 
-//    @Operation(summary = "사용자 정보 업데이트", description = "특정 사용자의 정보를 업데이트 하는 API 입니다.")
-//    @ApiResponses(value = {
-//            @ApiResponse(responseCode = "200", description = "사용자 정보 업데이트 성공"),
-//            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-//            @ApiResponse(responseCode= "404", description = "사용자를 찾지 못함"),
-//    })
-//    @Parameters({
-//            @Parameter(name = "id", description = "사용자ID",
-//                    example = "1"),
-//            @Parameter(name = "username", description = "사용자이름, nullable",
-//                    example = "홍길동"),
-//            @Parameter(name = "studentNumber", description = "사용자 학번, nullable",
-//                    example = "201234567"),
-//            @Parameter(name = "role", description = "사용자 역할", example = "USER")
-//    })
-//    @PutMapping("/update")
-//    public ResponseEntity updateUser(@RequestBody UserUpdateDto userUpdateDto) {
-//        userService.updateUserById(userUpdateDto);
-//        return new ResponseEntity(HttpStatus.OK);
-//    }
-//
-//    @Operation(summary = "사용자 정보 삭제", description = "특정 사용자의 정보를 삭제 하는 API 입니다.(Soft Delete)")
-//    @ApiResponses(value = {
-//            @ApiResponse(responseCode = "200", description = "사용자 정보 삭제 성공"),
-//            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-//            @ApiResponse(responseCode= "404", description = "사용자를 찾지 못함"),
-//    })
-//    @Parameters({
-//            @Parameter(name = "id", description = "사용자ID",
-//                    example = "1"),
-//    })
-//    @DeleteMapping("/delete")
-//    public ResponseEntity deleteUser(@PathVariable UserDeleteDto userDeleteDto) {
-//        userService.deleteUserById(userDeleteDto);
-//        return new ResponseEntity(HttpStatus.OK);
-//    }
+    @Operation(summary = "사용자 정보 업데이트", description = "특정 사용자의 정보를 업데이트 하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 정보 업데이트 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode= "404", description = "사용자를 찾지 못함"),
+    })
+    @Parameters({
+            @Parameter(name = "id", description = "사용자ID",
+                    example = "1"),
+            @Parameter(name = "username", description = "사용자이름, nullable",
+                    example = "홍길동"),
+            @Parameter(name = "studentNumber", description = "사용자 학번, nullable",
+                    example = "201234567"),
+            @Parameter(name = "role", description = "사용자 역할", example = "USER")
+    })
+    @PutMapping("/update")
+    public ResponseEntity updateUser(@RequestBody @Valid UserUpdateDto userUpdateDto) {
+        userService.updateUserById(userUpdateDto);
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    @Operation(summary = "사용자 정보 삭제", description = "특정 사용자의 정보를 삭제 하는 API 입니다.(Soft Delete)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 정보 삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode= "404", description = "사용자를 찾지 못함"),
+    })
+    @Parameters({
+            @Parameter(name = "id", description = "사용자ID",
+                    example = "1"),
+    })
+    @DeleteMapping("/delete")
+    public ResponseEntity deleteUser(@RequestBody @Valid UserDeleteDto userDeleteDto) {
+        userService.deleteUserById(userDeleteDto);
+        return new ResponseEntity(HttpStatus.OK);
+    }
 }

--- a/src/main/java/org/clubs/blueheart/user/api/UserApi.java
+++ b/src/main/java/org/clubs/blueheart/user/api/UserApi.java
@@ -1,18 +1,18 @@
 package org.clubs.blueheart.user.api;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.clubs.blueheart.exception.CustomExceptionStatus;
+import org.clubs.blueheart.response.GlobalResponseHandler;
+import org.clubs.blueheart.response.ResponseStatus;
 import org.clubs.blueheart.user.application.UserService;
 import org.clubs.blueheart.user.dto.UserDeleteDto;
 import org.clubs.blueheart.user.dto.UserInfoDto;
 import org.clubs.blueheart.user.dto.UserUpdateDto;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,73 +30,106 @@ public class UserApi {
 
     @Operation(summary = "사용자 생성", description = "단일의 사용자를 생성하는 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "성공적으로 등록됨"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode= "404", description = "사용자를 찾지 못함")
-    })
-    @Parameters({
-            @Parameter(name = "username", description = "사용자이름",
-                    example = "홍길동"),
-            @Parameter(name = "studentNumber", description = "고유학번", example = "201234567"),
-            @Parameter(name = "role", description = "직책" , example = "USER")
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "성공적으로 등록됨",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseStatus.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionStatus.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾지 못함",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionStatus.class)
+                    )
+            )
     })
     @PostMapping("/create")
-    public ResponseEntity<HttpStatus> createUser(@RequestBody @Valid UserInfoDto userInfoDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> createUser(@RequestBody @Valid UserInfoDto userInfoDto) {
         userService.createUser(userInfoDto);
-        return ResponseEntity.ok(HttpStatus.OK);
+        return GlobalResponseHandler.success(ResponseStatus.USER_CREATED);
     }
 
-    @Operation(summary = "사용자 검색", description = "사용자 정보를 검색하는 API, keyword 가 없을 시 모두 반환")
+    @Operation(summary = "사용자 검색", description = "사용자 정보를 검색하는 API, keyword가 없을 시 모두 반환")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "사용자 검색 성공",
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 검색 성공",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = UserInfoDto.class))),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode = "404", description = "사용자를 찾지 못함"),
-    })
-    @Parameters({
-            @Parameter(name = "keyword", description = "사용자이름 혹은 고유학번",
-                    example = "201234567"),
+                            schema = @Schema(implementation = ResponseStatus.class))),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionStatus.class))),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾지 못함",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionStatus.class)))
     })
     @GetMapping("/search/{keyword}")
-    public ResponseEntity<List<UserInfoDto>> findUserByKeyword(@PathVariable String keyword) {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.findUserByKeyword(keyword));
+    public ResponseEntity<GlobalResponseHandler<List>> findUserByKeyword(@PathVariable String keyword) {
+        List<UserInfoDto> users = userService.findUserByKeyword(keyword);
+        return GlobalResponseHandler.success(ResponseStatus.USER_SEARCHED, users);
     }
 
     @Operation(summary = "사용자 정보 업데이트", description = "특정 사용자의 정보를 업데이트 하는 API 입니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "사용자 정보 업데이트 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode= "404", description = "사용자를 찾지 못함"),
-    })
-    @Parameters({
-            @Parameter(name = "id", description = "사용자ID",
-                    example = "1"),
-            @Parameter(name = "username", description = "사용자이름, nullable",
-                    example = "홍길동"),
-            @Parameter(name = "studentNumber", description = "사용자 학번, nullable",
-                    example = "201234567"),
-            @Parameter(name = "role", description = "사용자 역할", example = "USER")
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 정보 업데이트 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseStatus.class))),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionStatus.class))),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾지 못함",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionStatus.class)))
     })
     @PutMapping("/update")
-    public ResponseEntity<HttpStatus> updateUser(@RequestBody @Valid UserUpdateDto userUpdateDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> updateUser(@RequestBody @Valid UserUpdateDto userUpdateDto) {
         userService.updateUserById(userUpdateDto);
-        return ResponseEntity.ok(HttpStatus.OK);
+        return GlobalResponseHandler.success(ResponseStatus.USER_UPDATED);
     }
 
-    @Operation(summary = "사용자 정보 삭제", description = "특정 사용자의 정보를 삭제 하는 API 입니다.(Soft Delete)")
+    @Operation(summary = "사용자 정보 삭제", description = "특정 사용자의 정보를 삭제 하는 API 입니다. (Soft Delete)")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "사용자 정보 삭제 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
-            @ApiResponse(responseCode= "404", description = "사용자를 찾지 못함"),
-    })
-    @Parameters({
-            @Parameter(name = "id", description = "사용자ID",
-                    example = "1"),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 정보 삭제 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseStatus.class))),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionStatus.class))),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾지 못함",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = CustomExceptionStatus.class)))
     })
     @DeleteMapping("/delete")
-    public ResponseEntity<HttpStatus> deleteUser(@RequestBody @Valid UserDeleteDto userDeleteDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> deleteUser(@RequestBody @Valid UserDeleteDto userDeleteDto) {
         userService.deleteUserById(userDeleteDto);
-        return ResponseEntity.ok(HttpStatus.OK);
+        return GlobalResponseHandler.success(ResponseStatus.USER_DELETED);
     }
 }

--- a/src/main/java/org/clubs/blueheart/user/api/UserApi.java
+++ b/src/main/java/org/clubs/blueheart/user/api/UserApi.java
@@ -80,7 +80,7 @@ public class UserApi {
                             schema = @Schema(implementation = CustomExceptionStatus.class)))
     })
     @GetMapping("/search/{keyword}")
-    public ResponseEntity<GlobalResponseHandler<List>> findUserByKeyword(@PathVariable String keyword) {
+    public ResponseEntity<GlobalResponseHandler<List<UserInfoDto>>> findUserByKeyword(@PathVariable String keyword) {
         List<UserInfoDto> users = userService.findUserByKeyword(keyword);
         return GlobalResponseHandler.success(ResponseStatus.USER_SEARCHED, users);
     }

--- a/src/main/java/org/clubs/blueheart/user/application/UserService.java
+++ b/src/main/java/org/clubs/blueheart/user/application/UserService.java
@@ -1,7 +1,9 @@
 package org.clubs.blueheart.user.application;
 
 import org.clubs.blueheart.user.dao.UserRepository;
+import org.clubs.blueheart.user.dto.UserDeleteDto;
 import org.clubs.blueheart.user.dto.UserInfoDto;
+import org.clubs.blueheart.user.dto.UserUpdateDto;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -34,14 +36,14 @@ public class UserService {
     }
 
 
-//    public ResponseEntity updateUserById(UserUpdateDto userUpdateDto) {
-//        userRepository.updateUserById(userUpdateDto);
-//    }
-//
-//
-//    public ResponseEntity deleteUserById(UserDeleteDto userDeleteDto) {
-//        userRepository.deleteUserById(userDeleteDto);
-//    }
+    public void updateUserById(UserUpdateDto userUpdateDto) {
+        userRepository.updateUserById(userUpdateDto);
+    }
+
+
+    public void deleteUserById(UserDeleteDto userDeleteDto) {
+        userRepository.deleteUserById(userDeleteDto);
+    }
 
 
 }

--- a/src/main/java/org/clubs/blueheart/user/dao/UserCustomDao.java
+++ b/src/main/java/org/clubs/blueheart/user/dao/UserCustomDao.java
@@ -6,5 +6,4 @@ import org.clubs.blueheart.user.dto.UserUpdateDto;
 public interface UserCustomDao {
 
     void updateUser(String username, String studentNumber, UserRole userRole);
-
 }

--- a/src/main/java/org/clubs/blueheart/user/dao/UserCustomDaoImpl.java
+++ b/src/main/java/org/clubs/blueheart/user/dao/UserCustomDaoImpl.java
@@ -22,6 +22,4 @@ public class UserCustomDaoImpl implements UserCustomDao {
                     validateUserRole(userRole))
             .fetch();
     }
-
-
 }

--- a/src/main/java/org/clubs/blueheart/user/dao/UserDao.java
+++ b/src/main/java/org/clubs/blueheart/user/dao/UserDao.java
@@ -7,6 +7,9 @@ import java.util.List;
 import java.util.Optional;
 
 public interface UserDao extends UserCustomDao, JpaRepository<User, Long> {
-    Optional<List<User>> findUsersByUsernameContains(String userName);  // JPA Query Method
-    Optional<List<User>> findUsersByStudentNumberStartsWith(String studentNumber); // JPA Query Method
+    Optional<List<User>> findUsersByUsernameContainsAndDeletedAtIsNull(String userName);  // JPA Query Method
+    Optional<List<User>> findUsersByStudentNumberStartsWithAndDeletedAtIsNull(String studentNumber); // JPA Query Method
+    Optional<User> findUserByIdAndDeletedAtIsNull(Long id);
+    Boolean existsByStudentNumberAndDeletedAtIsNull(String studentNumber);
+    Boolean existsByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/org/clubs/blueheart/user/dao/UserDao.java
+++ b/src/main/java/org/clubs/blueheart/user/dao/UserDao.java
@@ -11,5 +11,4 @@ public interface UserDao extends UserCustomDao, JpaRepository<User, Long> {
     Optional<List<User>> findUsersByStudentNumberStartsWithAndDeletedAtIsNull(String studentNumber); // JPA Query Method
     Optional<User> findUserByIdAndDeletedAtIsNull(Long id);
     Boolean existsByStudentNumberAndDeletedAtIsNull(String studentNumber);
-    Boolean existsByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/org/clubs/blueheart/user/dao/UserRepository.java
+++ b/src/main/java/org/clubs/blueheart/user/dao/UserRepository.java
@@ -1,7 +1,9 @@
 
 package org.clubs.blueheart.user.dao;
 
+import org.clubs.blueheart.user.dto.UserDeleteDto;
 import org.clubs.blueheart.user.dto.UserInfoDto;
+import org.clubs.blueheart.user.dto.UserUpdateDto;
 
 import java.util.List;
 
@@ -13,8 +15,8 @@ public interface UserRepository  {
 
     List<UserInfoDto> findUserByUsername(String username);
 
-//    void updateUserById(UserUpdateDto userUpdateDto);
-//
-//    void deleteUserById(UserDeleteDto userDeleteDto);
+    void updateUserById(UserUpdateDto userUpdateDto);
+
+    void deleteUserById(UserDeleteDto userDeleteDto);
 
 }

--- a/src/main/java/org/clubs/blueheart/user/domain/User.java
+++ b/src/main/java/org/clubs/blueheart/user/domain/User.java
@@ -22,35 +22,28 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class User {
 
+    // ManyToMany 반대편
+    @ManyToMany(mappedBy = "users")
+    private final java.util.Set<Group> groups = new java.util.HashSet<>();
+    @ManyToMany(mappedBy = "users")
+    private final java.util.Set<Group> activities = new java.util.HashSet<>();
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
     @NotNull
     @Column(nullable = false, length = 10)
     private String username;
-
     @NotNull
     @Column(name = "student_number", nullable = false, unique = true)
     private String studentNumber;
-
     @NotNull
     @Enumerated(EnumType.STRING)
     private UserRole role;
-
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
-
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
-
-    // ManyToMany 반대편
-    @ManyToMany(mappedBy = "users")
-    private java.util.Set<Group> groups = new java.util.HashSet<>();
-
-    @ManyToMany(mappedBy = "users")
-    private java.util.Set<Group> activities = new java.util.HashSet<>();
 
 
     @Builder(toBuilder = true)

--- a/src/main/java/org/clubs/blueheart/user/domain/User.java
+++ b/src/main/java/org/clubs/blueheart/user/domain/User.java
@@ -53,10 +53,21 @@ public class User {
     private java.util.Set<Group> activities = new java.util.HashSet<>();
 
 
-    @Builder
-    public User(String username, String studentNumber, UserRole role) {
+    @Builder(toBuilder = true)
+    private User(Long id, String username, String studentNumber, UserRole role, LocalDateTime createdAt, LocalDateTime deletedAt) {
+        this.id = id;
         this.username = username;
         this.studentNumber = studentNumber;
         this.role = role;
+        this.createdAt = createdAt;
+        this.deletedAt = deletedAt;
+    }
+
+    public User updatedUserFields(String username, String studentNumber, UserRole role) {
+        return this.toBuilder()
+                .username(username != null ? username : this.username)
+                .studentNumber(studentNumber != null ? studentNumber : this.studentNumber)
+                .role(role != null ? role : this.role)
+                .build();
     }
 }

--- a/src/main/java/org/clubs/blueheart/user/dto/UserUpdateDto.java
+++ b/src/main/java/org/clubs/blueheart/user/dto/UserUpdateDto.java
@@ -15,5 +15,5 @@ public class UserUpdateDto {
 
     private Optional<String> studentNumber = Optional.empty();
 
-    private Optional<UserRole> userRole = Optional.empty();
+    private Optional<UserRole> role = Optional.empty();
 }

--- a/src/main/java/org/clubs/blueheart/user/util/UserValidationUtil.java
+++ b/src/main/java/org/clubs/blueheart/user/util/UserValidationUtil.java
@@ -35,7 +35,7 @@ public class UserValidationUtil {
         }
 
         // QueryDSL 조건 반환
-        return user.user.role.eq(userRole);
+        return user.role.eq(userRole);
     }
 
     // Enum 값 검증 메서드

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,6 +10,7 @@ spring.datasource.password=password
 # H2 Console ??
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
+spring.h2.console.settings.web-allow-others= true
 
 # JPA ??
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## #️⃣연관된 이슈
#6 #9

## 📝작업 내용
- 코드 가독성을 증가시키고 반환 형태의 결합도를 낮추는 작업을 진행했습니다.
- 가독성 증가를 위해서 레이어별 try-catch 구조가 아닌 Global Exception Handler 도입
- 그에 따라 enum으로 ErrorCode 관리
- 반대로 성공하는 상황에 따른 Response Handler 도입
- 이를 관리하기 위한 문서화 진행 `https://www.notion.so/Status-Code-17660f255040805f907af54d3b539806?pvs=25`


### 스크린샷 (선택)
<img width="630" alt="스크린샷 2025-01-10 오전 4 17 17" src="https://github.com/user-attachments/assets/5ccd0b52-926c-4f81-8fab-ff18a715f33c" />

## 💬리뷰 요구사항(선택)
- 추후에 Activity Api 관련 부분도 올릴 예정입니다. (과도한 양 방지를 위해 일단 임시 저장 후 PR)
- Status Code 페이지는 작업하면서 꾸준히 추가예정입니다!

## 참고
[Cabi/backend/exception]https://github.com/innovationacademy-kr/Cabi/tree/dev/backend/src/main/java/org/ftclub/cabinet/exception

[[Java] Global Exception 이해하고 구성하기 : Controller Exception ]https://adjh54.tistory.com/79


[Spring: 예외 처리 - 쉽게 관심사 나누기 Global Exception Handler(Controller Advice)] https://velog.io/@letsdev/Spring-%EC%98%88%EC%99%B8-%EC%B2%98%EB%A6%AC-%EC%89%BD%EA%B2%8C-%EA%B4%80%EC%8B%AC%EC%82%AC-%EB%82%98%EB%88%84%EA%B8%B0-Global-Exception-HandlerController-Advice
