### PR TITLE
API 테스트 코드 작성 및 그에 따른 Dto Validation 순서보장 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,4 +56,6 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+
+    jvmArgs "-Xshare:off"
 }

--- a/src/main/java/org/clubs/blueheart/activity/api/ActivityApi.java
+++ b/src/main/java/org/clubs/blueheart/activity/api/ActivityApi.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Valid;
 import org.clubs.blueheart.activity.application.ActivityService;
 import org.clubs.blueheart.activity.domain.ActivityStatus;
 import org.clubs.blueheart.activity.dto.request.ActivityCreateRequestDto;

--- a/src/main/java/org/clubs/blueheart/activity/api/ActivityApi.java
+++ b/src/main/java/org/clubs/blueheart/activity/api/ActivityApi.java
@@ -13,10 +13,12 @@ import org.clubs.blueheart.activity.dto.request.ActivityDeleteRequestDto;
 import org.clubs.blueheart.activity.dto.request.ActivityUpdateRequestDto;
 import org.clubs.blueheart.activity.dto.response.ActivityDetailResponseDto;
 import org.clubs.blueheart.activity.dto.response.ActivitySearchResponseDto;
+import org.clubs.blueheart.config.ValidationSequenceConfig;
 import org.clubs.blueheart.exception.CustomExceptionStatus;
 import org.clubs.blueheart.response.GlobalResponseHandler;
 import org.clubs.blueheart.response.ResponseStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -52,7 +54,7 @@ public class ActivityApi {
             )
     })
     @PostMapping("/create")
-    public ResponseEntity<GlobalResponseHandler<Void>> createActivity(@RequestBody @Valid ActivityCreateRequestDto activityCreateRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> createActivity(@RequestBody @Validated(ValidationSequenceConfig.class) ActivityCreateRequestDto activityCreateRequestDto) {
         activityService.createActivity(activityCreateRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_CREATED);
     }
@@ -85,7 +87,7 @@ public class ActivityApi {
             )
     })
     @PutMapping("/update")
-    public ResponseEntity<GlobalResponseHandler<Void>> updateActivity(@RequestBody @Valid ActivityUpdateRequestDto activityUpdateRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> updateActivity(@RequestBody @Validated(ValidationSequenceConfig.class) ActivityUpdateRequestDto activityUpdateRequestDto) {
         activityService.updateActivity(activityUpdateRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_UPDATED);
     }
@@ -185,7 +187,7 @@ public class ActivityApi {
             )
     })
     @DeleteMapping("/delete")
-    public ResponseEntity<GlobalResponseHandler<Void>> deleteActivity(@RequestBody @Valid ActivityDeleteRequestDto activityDeleteRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> deleteActivity(@RequestBody @Validated(ValidationSequenceConfig.class) ActivityDeleteRequestDto activityDeleteRequestDto) {
         activityService.deleteActivity(activityDeleteRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_DELETED);
     }

--- a/src/main/java/org/clubs/blueheart/activity/api/ActivityHistoryApi.java
+++ b/src/main/java/org/clubs/blueheart/activity/api/ActivityHistoryApi.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Valid;
 import org.clubs.blueheart.activity.application.ActivityHistoryService;
 import org.clubs.blueheart.activity.dto.request.ActivitySubscribeRequestDto;
 import org.clubs.blueheart.activity.dto.response.ActivitySearchResponseDto;

--- a/src/main/java/org/clubs/blueheart/activity/api/ActivityHistoryApi.java
+++ b/src/main/java/org/clubs/blueheart/activity/api/ActivityHistoryApi.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import org.clubs.blueheart.activity.application.ActivityHistoryService;
 import org.clubs.blueheart.activity.dto.request.ActivitySubscribeRequestDto;
 import org.clubs.blueheart.activity.dto.response.ActivitySearchResponseDto;
+import org.clubs.blueheart.config.ValidationSequenceConfig;
 import org.clubs.blueheart.config.jwt.JwtUserDetails;
 import org.clubs.blueheart.exception.CustomExceptionStatus;
 import org.clubs.blueheart.response.GlobalResponseHandler;
@@ -16,6 +17,7 @@ import org.clubs.blueheart.response.ResponseStatus;
 import org.clubs.blueheart.user.dto.response.UserInfoResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -59,7 +61,7 @@ public class ActivityHistoryApi {
             )
     })
     @PostMapping("/subscribe")
-    public ResponseEntity<GlobalResponseHandler<Void>> subscribeActivity(@RequestBody @Valid ActivitySubscribeRequestDto activitySubscribeRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> subscribeActivity(@RequestBody @Validated(ValidationSequenceConfig.class) ActivitySubscribeRequestDto activitySubscribeRequestDto) {
         activityHistoryService.subscribeActivity(activitySubscribeRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_HISTORY_SUBSCRIBED);
     }
@@ -92,7 +94,7 @@ public class ActivityHistoryApi {
             )
     })
     @PostMapping("/unsubscribe")
-    public ResponseEntity<GlobalResponseHandler<Void>> unsubscribeActivity(@RequestBody @Valid ActivitySubscribeRequestDto activitySubscribeRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> unsubscribeActivity(@RequestBody @Validated(ValidationSequenceConfig.class) ActivitySubscribeRequestDto activitySubscribeRequestDto) {
         activityHistoryService.unsubscribeActivity(activitySubscribeRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_HISTORY_UNSUBSCRIBED);
     }
@@ -160,7 +162,7 @@ public class ActivityHistoryApi {
             )
     })
     @GetMapping("/{activityId}")
-    public ResponseEntity<GlobalResponseHandler<List<UserInfoResponseDto>>> findSubscribedUser(@PathVariable @Valid Long activityId) {
+    public ResponseEntity<GlobalResponseHandler<List<UserInfoResponseDto>>> findSubscribedUser(@PathVariable @Validated(ValidationSequenceConfig.class) Long activityId) {
         List<UserInfoResponseDto> users = activityHistoryService.findSubscribedUser(activityId);
         return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_SEARCHED, users);
     }

--- a/src/main/java/org/clubs/blueheart/activity/api/ActivityHistoryApi.java
+++ b/src/main/java/org/clubs/blueheart/activity/api/ActivityHistoryApi.java
@@ -94,7 +94,7 @@ public class ActivityHistoryApi {
     @PostMapping("/unsubscribe")
     public ResponseEntity<GlobalResponseHandler<Void>> unsubscribeActivity(@RequestBody @Valid ActivitySubscribeRequestDto activitySubscribeRequestDto) {
         activityHistoryService.unsubscribeActivity(activitySubscribeRequestDto);
-        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_HISTORY_SUBSCRIBED);
+        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_HISTORY_UNSUBSCRIBED);
     }
 
     @Operation(summary = "Get My Activity History", description = "Retrieves the current user's activity subscription history.")

--- a/src/main/java/org/clubs/blueheart/activity/dao/ActivityHistoryCustomDaoImpl.java
+++ b/src/main/java/org/clubs/blueheart/activity/dao/ActivityHistoryCustomDaoImpl.java
@@ -1,4 +1,4 @@
 package org.clubs.blueheart.activity.dao;
 
-public class AcitivityHistoryCustomDaoImpl {
+public class ActivityHistoryCustomDaoImpl {
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityCreateRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityCreateRequestDto.java
@@ -1,7 +1,6 @@
 package org.clubs.blueheart.activity.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Data;
 
@@ -11,23 +10,34 @@ import java.time.LocalDateTime;
 @Builder
 public class ActivityCreateRequestDto {
 
-    @NotNull(message = "Creator ID must not be null")
+    @NotBlank(message = "Creator ID must not be blank")
+    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long creatorId;
 
-    @NotNull(message = "Title must not be null")
+    @NotBlank(message = "Title must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$")
     private String title;
 
     @NotBlank(message = "MaxNumber must not be blank")
+    @Size(min = 1, max = 999, message = "최대값은 999이하입니다")
     private Integer maxNumber;
 
-    @NotNull(message = "Description must not be null")
+    @NotBlank(message = "Description must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
+    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
     private String description;
 
-    @NotNull(message = "Place must not be null")
+    @NotBlank(message = "Place must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
+    @Size(min = 1, max = 100, message = "내용은 100자 이하입니다")
     private String place;
 
-    @NotNull(message = "PlaceUrl must not be null")
+    @NotBlank(message = "PlaceUrl must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
+    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
     private String placeUrl;
 
+    @NotBlank(message = "expiredAt must not be blank")
+    @Future(message = "만료시각은 현재보다 뒤여야 합니다.")
     private LocalDateTime expiredAt;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityCreateRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityCreateRequestDto.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @Builder
 public class ActivityCreateRequestDto {
 
-    @NotBlank(message = "Creator ID must not be blank")
+    @NotNull(message = "Creator ID must not be blank")
     @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long creatorId;
 
@@ -18,8 +18,9 @@ public class ActivityCreateRequestDto {
     @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$")
     private String title;
 
-    @NotBlank(message = "MaxNumber must not be blank")
-    @Size(min = 1, max = 999, message = "최대값은 999이하입니다")
+    @NotNull(message = "MaxNumber must not be blank")
+    @Min(1)
+    @Max(999)
     private Integer maxNumber;
 
     @NotBlank(message = "Description must not be blank")
@@ -37,7 +38,7 @@ public class ActivityCreateRequestDto {
     @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
     private String placeUrl;
 
-    @NotBlank(message = "expiredAt must not be blank")
+    @NotNull(message = "expiredAt must not be blank")
     @Future(message = "만료시각은 현재보다 뒤여야 합니다.")
     private LocalDateTime expiredAt;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityCreateRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityCreateRequestDto.java
@@ -3,6 +3,7 @@ package org.clubs.blueheart.activity.dto.request;
 import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 
 import java.time.LocalDateTime;
 
@@ -10,35 +11,57 @@ import java.time.LocalDateTime;
 @Builder
 public class ActivityCreateRequestDto {
 
-    @NotNull(message = "Creator ID must not be blank")
-    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
+    @NotNull(message = "Creator ID must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "Creator ID must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long creatorId;
 
-    @NotBlank(message = "Title must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$")
+    @NotBlank(message = "Title must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Title can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
     private String title;
 
-    @NotNull(message = "MaxNumber must not be blank")
-    @Min(1)
-    @Max(999)
+    @NotNull(message = "Max number must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "Max number must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
+    @Max(value = 999, message = "Max number cannot exceed 999",
+            groups = ValidationGroups.SizeGroup.class)
     private Integer maxNumber;
 
-    @NotBlank(message = "Description must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
-    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
+    @NotBlank(message = "Description must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Description can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
+    @Size(min = 1, max = 255, message = "Description cannot exceed 255 characters",
+            groups = ValidationGroups.SizeGroup.class)
     private String description;
 
-    @NotBlank(message = "Place must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
-    @Size(min = 1, max = 100, message = "내용은 100자 이하입니다")
+    @NotBlank(message = "Place must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Place can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
+    @Size(min = 1, max = 100, message = "Place cannot exceed 100 characters",
+            groups = ValidationGroups.SizeGroup.class)
     private String place;
 
-    @NotBlank(message = "PlaceUrl must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
-    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
+    @NotBlank(message = "Place URL must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Place URL can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
+    @Size(min = 1, max = 255, message = "Place URL cannot exceed 255 characters",
+            groups = ValidationGroups.SizeGroup.class)
     private String placeUrl;
 
-    @NotNull(message = "expiredAt must not be blank")
-    @Future(message = "만료시각은 현재보다 뒤여야 합니다.")
+    @NotNull(message = "Expiration time must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Future(message = "Expiration time must be in the future",
+            groups = ValidationGroups.DateTimeGroup.class)
     private LocalDateTime expiredAt;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityDeleteRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityDeleteRequestDto.java
@@ -4,12 +4,15 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 
 @Data
 @Builder
 public class ActivityDeleteRequestDto {
 
-    @NotNull(message = "ActivityId must not be blank")
-    @Min(value = 1, message = "ActivityId는 1이상이어야합니다.")
+    @NotNull(message = "ActivityId must not be blank",
+    groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "ActivityId must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long activityId;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityDeleteRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityDeleteRequestDto.java
@@ -1,5 +1,7 @@
 package org.clubs.blueheart.activity.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,5 +9,7 @@ import lombok.Data;
 @Builder
 public class ActivityDeleteRequestDto {
 
+    @NotBlank(message = "ID must not be blank")
+    @Min(value = 1, message = "ID는 1이상이어야합니다.")
     private Long id;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityDeleteRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityDeleteRequestDto.java
@@ -1,7 +1,7 @@
 package org.clubs.blueheart.activity.dto.request;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,7 +9,7 @@ import lombok.Data;
 @Builder
 public class ActivityDeleteRequestDto {
 
-    @NotBlank(message = "ActivityId must not be blank")
+    @NotNull(message = "ActivityId must not be blank")
     @Min(value = 1, message = "ActivityId는 1이상이어야합니다.")
     private Long activityId;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityDeleteRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityDeleteRequestDto.java
@@ -9,7 +9,7 @@ import lombok.Data;
 @Builder
 public class ActivityDeleteRequestDto {
 
-    @NotBlank(message = "ID must not be blank")
-    @Min(value = 1, message = "ID는 1이상이어야합니다.")
-    private Long id;
+    @NotBlank(message = "ActivityId must not be blank")
+    @Min(value = 1, message = "ActivityId는 1이상이어야합니다.")
+    private Long activityId;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivitySubscribeRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivitySubscribeRequestDto.java
@@ -4,16 +4,21 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 
 @Data
 @Builder
 public class ActivitySubscribeRequestDto {
 
-    @NotNull(message = "ActivityId must not be null")
-    @Min(value = 1, message = "액티비티ID는 1이상이어야합니다.")
+    @NotNull(message = "ActivityId must not be blank",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "ActivityId must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long activityId;
 
-    @NotNull(message = "UserId must not be null")
-    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
+    @NotNull(message = "UserId must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "User ID must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long userId;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivitySubscribeRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivitySubscribeRequestDto.java
@@ -10,7 +10,7 @@ import org.clubs.blueheart.config.ValidationGroups;
 @Builder
 public class ActivitySubscribeRequestDto {
 
-    @NotNull(message = "ActivityId must not be blank",
+    @NotNull(message = "ActivityId must not be null",
             groups = ValidationGroups.NotNullGroup.class)
     @Min(value = 1, message = "ActivityId must be at least 1",
             groups = ValidationGroups.SizeGroup.class)

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivitySubscribeRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivitySubscribeRequestDto.java
@@ -1,7 +1,7 @@
 package org.clubs.blueheart.activity.dto.request;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,11 +9,11 @@ import lombok.Data;
 @Builder
 public class ActivitySubscribeRequestDto {
 
-    @NotBlank(message = "ActivityId must not be blank")
+    @NotNull(message = "ActivityId must not be blank")
     @Min(value = 1, message = "액티비티ID는 1이상이어야합니다.")
     private Long activityId;
 
-    @NotBlank(message = "UserId must not be blank")
+    @NotNull(message = "UserId must not be blank")
     @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivitySubscribeRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivitySubscribeRequestDto.java
@@ -9,11 +9,11 @@ import lombok.Data;
 @Builder
 public class ActivitySubscribeRequestDto {
 
-    @NotBlank(message = "Activity ID must not be blank")
+    @NotBlank(message = "ActivityId must not be blank")
     @Min(value = 1, message = "액티비티ID는 1이상이어야합니다.")
     private Long activityId;
 
-    @NotBlank(message = "Userid must not be blank")
+    @NotBlank(message = "UserId must not be blank")
     @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivitySubscribeRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivitySubscribeRequestDto.java
@@ -9,11 +9,11 @@ import lombok.Data;
 @Builder
 public class ActivitySubscribeRequestDto {
 
-    @NotNull(message = "ActivityId must not be blank")
+    @NotNull(message = "ActivityId must not be null")
     @Min(value = 1, message = "액티비티ID는 1이상이어야합니다.")
     private Long activityId;
 
-    @NotNull(message = "UserId must not be blank")
+    @NotNull(message = "UserId must not be null")
     @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivitySubscribeRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivitySubscribeRequestDto.java
@@ -1,5 +1,7 @@
 package org.clubs.blueheart.activity.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,7 +9,11 @@ import lombok.Data;
 @Builder
 public class ActivitySubscribeRequestDto {
 
+    @NotBlank(message = "Activity ID must not be blank")
+    @Min(value = 1, message = "액티비티ID는 1이상이어야합니다.")
     private Long activityId;
 
+    @NotBlank(message = "Userid must not be blank")
+    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityUpdateRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityUpdateRequestDto.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @Builder
 public class ActivityUpdateRequestDto {
 
-    @NotBlank(message = "ActivityId must not be blank")
+    @NotNull(message = "ActivityId must not be blank")
     @Min(value = 1, message = "ActivityId는 1이상이어야합니다.")
     private Long activityId;
 
@@ -19,12 +19,12 @@ public class ActivityUpdateRequestDto {
     @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$")
     private String title;
 
-    @NotBlank(message = "Status must not be blank")
-    @Pattern(regexp = "^[A-Z]*$")
+    @NotNull(message = "Status must not be blank")
     private ActivityStatus status;
 
-    @NotBlank(message = "MaxNumber must not be blank")
-    @Size(min = 1, max = 999, message = "최대값은 999이하입니다")
+    @NotNull(message = "MaxNumber must not be blank")
+    @Min(1)
+    @Max(999)
     private Integer maxNumber;
 
     @NotBlank(message = "Description must not be blank")
@@ -42,7 +42,7 @@ public class ActivityUpdateRequestDto {
     @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
     private String placeUrl;
 
-    @NotBlank(message = "expiredAt must not be blank")
+    @NotNull(message = "expiredAt must not be blank")
     @Future(message = "만료시각은 현재보다 뒤여야 합니다.")
     private LocalDateTime expiredAt;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityUpdateRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityUpdateRequestDto.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Data;
 import org.clubs.blueheart.activity.domain.ActivityStatus;
+import org.clubs.blueheart.config.ValidationGroups;
 
 import java.time.LocalDateTime;
 
@@ -11,38 +12,61 @@ import java.time.LocalDateTime;
 @Builder
 public class ActivityUpdateRequestDto {
 
-    @NotNull(message = "ActivityId must not be blank")
-    @Min(value = 1, message = "ActivityId는 1이상이어야합니다.")
+    @NotNull(message = "Activity ID must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "Activity ID must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long activityId;
 
-    @NotBlank(message = "Title must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$")
+    @NotBlank(message = "Title must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Title can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
     private String title;
 
-    @NotNull(message = "Status must not be blank")
+    @NotNull(message = "Status must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
     private ActivityStatus status;
 
-    @NotNull(message = "MaxNumber must not be blank")
-    @Min(1)
-    @Max(999)
+    @NotNull(message = "Max number must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+
+    @Size(min = 1, max = 999,
+            message = "MaxNumber cannot exceed 999",
+            groups = ValidationGroups.SizeGroup.class)
     private Integer maxNumber;
 
-    @NotBlank(message = "Description must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
-    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
+    @NotBlank(message = "Description must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Description can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
+    @Size(min = 1, max = 255, message = "Description cannot exceed 255 characters",
+            groups = ValidationGroups.SizeGroup.class)
     private String description;
 
-    @NotBlank(message = "Place must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
-    @Size(min = 1, max = 100, message = "내용은 100자 이하입니다")
+    @NotBlank(message = "Place must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Place can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
+    @Size(min = 1, max = 100, message = "Place cannot exceed 100 characters",
+            groups = ValidationGroups.SizeGroup.class)
     private String place;
 
-    @NotBlank(message = "PlaceUrl must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
-    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
+    @NotBlank(message = "Place URL must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Place URL can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
+    @Size(min = 1, max = 255, message = "Place URL cannot exceed 255 characters",
+            groups = ValidationGroups.SizeGroup.class)
     private String placeUrl;
 
-    @NotNull(message = "expiredAt must not be blank")
-    @Future(message = "만료시각은 현재보다 뒤여야 합니다.")
+    @NotNull(message = "Expiration time must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Future(message = "Expiration time must be in the future",
+            groups = ValidationGroups.DateTimeGroup.class)
     private LocalDateTime expiredAt;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityUpdateRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityUpdateRequestDto.java
@@ -32,8 +32,9 @@ public class ActivityUpdateRequestDto {
     @NotNull(message = "Max number must not be null",
             groups = ValidationGroups.NotNullGroup.class)
 
-    @Size(min = 1, max = 999,
-            message = "MaxNumber cannot exceed 999",
+    @Min(value = 1, message = "Max number must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
+    @Max(value = 999, message = "Max number cannot exceed 999",
             groups = ValidationGroups.SizeGroup.class)
     private Integer maxNumber;
 

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityUpdateRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityUpdateRequestDto.java
@@ -1,7 +1,6 @@
 package org.clubs.blueheart.activity.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Data;
 import org.clubs.blueheart.activity.domain.ActivityStatus;
@@ -12,25 +11,38 @@ import java.time.LocalDateTime;
 @Builder
 public class ActivityUpdateRequestDto {
 
-    @NotNull(message = "id must not be null")
-    private Long id;
+    @NotBlank(message = "Creator ID must not be blank")
+    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
+    private Long creatorId;
 
-    @NotNull(message = "Title must not be null")
+    @NotBlank(message = "Title must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$")
     private String title;
 
+    @NotBlank(message = "Status must not be blank")
+    @Pattern(regexp = "^[A-Z]*$")
     private ActivityStatus status;
 
     @NotBlank(message = "MaxNumber must not be blank")
+    @Size(min = 1, max = 999, message = "최대값은 999이하입니다")
     private Integer maxNumber;
 
-    @NotNull(message = "Description must not be null")
+    @NotBlank(message = "Description must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
+    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
     private String description;
 
-    @NotNull(message = "Place must not be null")
+    @NotBlank(message = "Place must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
+    @Size(min = 1, max = 100, message = "내용은 100자 이하입니다")
     private String place;
 
-    @NotNull(message = "PlaceUrl must not be null")
+    @NotBlank(message = "PlaceUrl must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
+    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
     private String placeUrl;
 
+    @NotBlank(message = "expiredAt must not be blank")
+    @Future(message = "만료시각은 현재보다 뒤여야 합니다.")
     private LocalDateTime expiredAt;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityUpdateRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/request/ActivityUpdateRequestDto.java
@@ -11,9 +11,9 @@ import java.time.LocalDateTime;
 @Builder
 public class ActivityUpdateRequestDto {
 
-    @NotBlank(message = "Creator ID must not be blank")
-    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
-    private Long creatorId;
+    @NotBlank(message = "ActivityId must not be blank")
+    @Min(value = 1, message = "ActivityId는 1이상이어야합니다.")
+    private Long activityId;
 
     @NotBlank(message = "Title must not be blank")
     @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$")

--- a/src/main/java/org/clubs/blueheart/activity/dto/response/ActivityDetailResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/response/ActivityDetailResponseDto.java
@@ -1,5 +1,8 @@
 package org.clubs.blueheart.activity.dto.response;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
@@ -9,10 +12,19 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode(callSuper = true)
 public class ActivityDetailResponseDto extends ActivitySearchResponseDto {
 
+    @NotBlank(message = "Description must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
+    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
     private String description;
 
+    @NotBlank(message = "Place must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
+    @Size(min = 1, max = 100, message = "내용은 100자 이하입니다")
     private String place;
 
+    @NotBlank(message = "PlaceUrl must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
+    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
     private String placeUrl;
 
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/response/ActivityDetailResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/response/ActivityDetailResponseDto.java
@@ -13,18 +13,21 @@ import lombok.experimental.SuperBuilder;
 public class ActivityDetailResponseDto extends ActivitySearchResponseDto {
 
     @NotBlank(message = "Description must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
-    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Description can only contain letters, numbers, and symbols")
+    @Size(min = 1, max = 255, message = "Description cannot exceed 255 characters")
     private String description;
 
     @NotBlank(message = "Place must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
-    @Size(min = 1, max = 100, message = "내용은 100자 이하입니다")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Place can only contain letters, numbers, and symbols")
+    @Size(min = 1, max = 100, message = "Place cannot exceed 100 characters")
     private String place;
 
-    @NotBlank(message = "PlaceUrl must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
-    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
+    @NotBlank(message = "Place URL must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Place URL can only contain letters, numbers, and symbols")
+    @Size(min = 1, max = 255, message = "Place URL cannot exceed 255 characters")
     private String placeUrl;
 
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/response/ActivityDetailResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/response/ActivityDetailResponseDto.java
@@ -6,28 +6,37 @@ import jakarta.validation.constraints.Size;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.SuperBuilder;
+import org.clubs.blueheart.config.ValidationGroups;
 
 @Data
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)
 public class ActivityDetailResponseDto extends ActivitySearchResponseDto {
 
-    @NotBlank(message = "Description must not be blank")
+    @NotBlank(message = "Description must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
     @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
-            message = "Description can only contain letters, numbers, and symbols")
-    @Size(min = 1, max = 255, message = "Description cannot exceed 255 characters")
+            message = "Description can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
+    @Size(min = 1, max = 255, message = "Description cannot exceed 255 characters",
+            groups = ValidationGroups.SizeGroup.class)
     private String description;
 
-    @NotBlank(message = "Place must not be blank")
+    @NotBlank(message = "Place must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
     @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
-            message = "Place can only contain letters, numbers, and symbols")
-    @Size(min = 1, max = 100, message = "Place cannot exceed 100 characters")
+            message = "Place can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
+    @Size(min = 1, max = 100, message = "Place cannot exceed 100 characters",
+            groups = ValidationGroups.SizeGroup.class)
     private String place;
 
-    @NotBlank(message = "Place URL must not be blank")
+    @NotBlank(message = "Place URL must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
     @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
-            message = "Place URL can only contain letters, numbers, and symbols")
-    @Size(min = 1, max = 255, message = "Place URL cannot exceed 255 characters")
+            message = "Place URL can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
+    @Size(min = 1, max = 255, message = "Place URL cannot exceed 255 characters",
+            groups = ValidationGroups.SizeGroup.class)
     private String placeUrl;
-
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/response/ActivitySearchResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/response/ActivitySearchResponseDto.java
@@ -1,7 +1,6 @@
 package org.clubs.blueheart.activity.dto.response;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.Data;
 import lombok.experimental.SuperBuilder;
 import org.clubs.blueheart.activity.domain.ActivityStatus;
@@ -12,23 +11,35 @@ import java.time.LocalDateTime;
 @SuperBuilder
 public class ActivitySearchResponseDto {
 
-    private Long id;
+    @NotBlank(message = "ActivityId must not be blank")
+    @Min(value = 1, message = "ActivityId는 1이상이어야합니다.")
+    private Long activityId;
 
-    @NotNull(message = "Title must not be null")
+    @NotBlank(message = "Title must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$")
     private String title;
 
+    @NotBlank(message = "Status must not be blank")
+    @Pattern(regexp = "^[A-Z]*$")
     private ActivityStatus status;
 
+    @NotBlank(message = "IsSubscribed must not be blank")
     private Boolean isSubscribed;
 
+    @NotBlank(message = "Place must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
+    @Size(min = 1, max = 100, message = "내용은 100자 이하입니다")
     private String place;
 
     @NotBlank(message = "CurrentNumber must not be blank")
+    @Size(min = 1, max = 999, message = "최대값은 999이하입니다")
     private Integer currentNumber;
 
     @NotBlank(message = "MaxNumber must not be blank")
+    @Size(min = 1, max = 999, message = "최대값은 999이하입니다")
     private Integer maxNumber;
 
+    @NotBlank(message = "expiredAt must not be blank")
+    @Future(message = "만료시각은 현재보다 뒤여야 합니다.")
     private LocalDateTime expiredAt;
-
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/response/ActivitySearchResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/response/ActivitySearchResponseDto.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @SuperBuilder
 public class ActivitySearchResponseDto {
 
-    @NotBlank(message = "ActivityId must not be blank")
+    @NotNull(message = "ActivityId must not be blank")
     @Min(value = 1, message = "ActivityId는 1이상이어야합니다.")
     private Long activityId;
 
@@ -32,14 +32,16 @@ public class ActivitySearchResponseDto {
     private String place;
 
     @NotBlank(message = "CurrentNumber must not be blank")
-    @Size(min = 1, max = 999, message = "최대값은 999이하입니다")
+    @Min(1)
+    @Max(999)
     private Integer currentNumber;
 
     @NotBlank(message = "MaxNumber must not be blank")
-    @Size(min = 1, max = 999, message = "최대값은 999이하입니다")
+    @Min(1)
+    @Max(999)
     private Integer maxNumber;
 
-    @NotBlank(message = "expiredAt must not be blank")
+    @NotNull(message = "expiredAt must not be blank")
     @Future(message = "만료시각은 현재보다 뒤여야 합니다.")
     private LocalDateTime expiredAt;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/response/ActivitySearchResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/response/ActivitySearchResponseDto.java
@@ -11,37 +11,38 @@ import java.time.LocalDateTime;
 @SuperBuilder
 public class ActivitySearchResponseDto {
 
-    @NotNull(message = "ActivityId must not be null")
-    @Min(value = 1, message = "ActivityId는 1이상이어야합니다.")
+    @NotNull(message = "Activity ID must not be null")
+    @Min(value = 1, message = "Activity ID must be at least 1")
     private Long activityId;
 
     @NotBlank(message = "Title must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Title can only contain letters, numbers, and symbols")
     private String title;
 
-    @NotBlank(message = "Status must not be blank")
-    @Pattern(regexp = "^[A-Z]*$")
+    @NotNull(message = "Status must not be null")
     private ActivityStatus status;
 
-    @NotBlank(message = "IsSubscribed must not be blank")
+    @NotNull(message = "IsSubscribed must not be null")
     private Boolean isSubscribed;
 
     @NotBlank(message = "Place must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
-    @Size(min = 1, max = 100, message = "내용은 100자 이하입니다")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Place can only contain letters, numbers, and symbols")
+    @Size(min = 1, max = 100, message = "Place cannot exceed 100 characters")
     private String place;
 
-    @NotBlank(message = "CurrentNumber must not be blank")
-    @Min(1)
-    @Max(999)
+    @NotNull(message = "Current number must not be null")
+    @Min(value = 1, message = "Current number must be at least 1")
+    @Max(value = 999, message = "Current number cannot exceed 999")
     private Integer currentNumber;
 
-    @NotBlank(message = "MaxNumber must not be blank")
-    @Min(1)
-    @Max(999)
+    @NotNull(message = "Max number must not be null")
+    @Min(value = 1, message = "Max number must be at least 1")
+    @Max(value = 999, message = "Max number cannot exceed 999")
     private Integer maxNumber;
 
-    @NotNull(message = "expiredAt must not be null")
-    @Future(message = "만료시각은 현재보다 뒤여야 합니다.")
+    @NotNull(message = "Expiration time must not be null")
+    @Future(message = "Expiration time must be in the future")
     private LocalDateTime expiredAt;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/response/ActivitySearchResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/response/ActivitySearchResponseDto.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 @SuperBuilder
 public class ActivitySearchResponseDto {
 
-    @NotNull(message = "ActivityId must not be blank")
+    @NotNull(message = "ActivityId must not be null")
     @Min(value = 1, message = "ActivityId는 1이상이어야합니다.")
     private Long activityId;
 
@@ -41,7 +41,7 @@ public class ActivitySearchResponseDto {
     @Max(999)
     private Integer maxNumber;
 
-    @NotNull(message = "expiredAt must not be blank")
+    @NotNull(message = "expiredAt must not be null")
     @Future(message = "만료시각은 현재보다 뒤여야 합니다.")
     private LocalDateTime expiredAt;
 }

--- a/src/main/java/org/clubs/blueheart/activity/dto/response/ActivitySearchResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/activity/dto/response/ActivitySearchResponseDto.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.*;
 import lombok.Data;
 import lombok.experimental.SuperBuilder;
 import org.clubs.blueheart.activity.domain.ActivityStatus;
+import org.clubs.blueheart.config.ValidationGroups;
 
 import java.time.LocalDateTime;
 
@@ -11,38 +12,55 @@ import java.time.LocalDateTime;
 @SuperBuilder
 public class ActivitySearchResponseDto {
 
-    @NotNull(message = "Activity ID must not be null")
-    @Min(value = 1, message = "Activity ID must be at least 1")
+    @NotNull(message = "Activity ID must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "Activity ID must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long activityId;
 
-    @NotBlank(message = "Title must not be blank")
+    @NotBlank(message = "Title must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
     @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
-            message = "Title can only contain letters, numbers, and symbols")
+            message = "Title can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
     private String title;
 
-    @NotNull(message = "Status must not be null")
+    @NotNull(message = "Status must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
     private ActivityStatus status;
 
-    @NotNull(message = "IsSubscribed must not be null")
+    @NotNull(message = "IsSubscribed must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
     private Boolean isSubscribed;
 
-    @NotBlank(message = "Place must not be blank")
+    @NotBlank(message = "Place must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
     @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
-            message = "Place can only contain letters, numbers, and symbols")
-    @Size(min = 1, max = 100, message = "Place cannot exceed 100 characters")
+            message = "Place can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
+    @Size(min = 1, max = 100, message = "Place cannot exceed 100 characters",
+            groups = ValidationGroups.SizeGroup.class)
     private String place;
 
-    @NotNull(message = "Current number must not be null")
-    @Min(value = 1, message = "Current number must be at least 1")
-    @Max(value = 999, message = "Current number cannot exceed 999")
+    @NotNull(message = "Current number must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "Current number must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
+    @Max(value = 999, message = "Current number cannot exceed 999",
+            groups = ValidationGroups.SizeGroup.class)
     private Integer currentNumber;
 
-    @NotNull(message = "Max number must not be null")
-    @Min(value = 1, message = "Max number must be at least 1")
-    @Max(value = 999, message = "Max number cannot exceed 999")
+    @NotNull(message = "Max number must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "Max number must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
+    @Max(value = 999, message = "Max number cannot exceed 999",
+            groups = ValidationGroups.SizeGroup.class)
     private Integer maxNumber;
 
-    @NotNull(message = "Expiration time must not be null")
-    @Future(message = "Expiration time must be in the future")
+    @NotNull(message = "Expiration time must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Future(message = "Expiration time must be in the future",
+            groups = ValidationGroups.DateTimeGroup.class)
     private LocalDateTime expiredAt;
 }

--- a/src/main/java/org/clubs/blueheart/activity/repository/ActivityHistoryRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/activity/repository/ActivityHistoryRepositoryImpl.java
@@ -93,7 +93,7 @@ public class ActivityHistoryRepositoryImpl implements ActivityHistoryRepository{
                 .map(activityHistory -> {
                     Activity activity = activityHistory.getActivity();
                     return ActivitySearchResponseDto.builder()
-                            .id(activity.getId()) // Use `id` field instead of `activityId`
+                            .activityId(activity.getId()) // Use `id` field instead of `activityId`
                             .title(activity.getTitle())
                             .place(activity.getPlace())
                             .isSubscribed(true)

--- a/src/main/java/org/clubs/blueheart/activity/repository/ActivityHistoryRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/activity/repository/ActivityHistoryRepositoryImpl.java
@@ -30,7 +30,7 @@ public class ActivityHistoryRepositoryImpl implements ActivityHistoryRepository{
     public void subscribeActivityById(ActivitySubscribeRequestDto activitySubscribeRequestDto) {
 
         if (activitySubscribeRequestDto == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.ACTIVITY_INVALID_PARAMS);
         }
 
         // Check if the user is already subscribed to the activity
@@ -58,7 +58,7 @@ public class ActivityHistoryRepositoryImpl implements ActivityHistoryRepository{
     public void unsubscribeActivityById(ActivitySubscribeRequestDto activitySubscribeRequestDto) {
 
         if (activitySubscribeRequestDto == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.ACTIVITY_INVALID_PARAMS);
         }
 
         // Fetch the existing ActivityHistory record
@@ -79,7 +79,7 @@ public class ActivityHistoryRepositoryImpl implements ActivityHistoryRepository{
     @Override
     public List<ActivitySearchResponseDto> getMyActivityHistoryInfoById(Long userId) {
         if (userId == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.ACTIVITY_INVALID_PARAMS);
         }
 
         // Fetch the activity history for the given user where ActivityStatus is PROGRESSING or COMPLETED
@@ -109,7 +109,7 @@ public class ActivityHistoryRepositoryImpl implements ActivityHistoryRepository{
     @Override
     public List<UserInfoResponseDto> findSubscribedUserByActivityId(Long activityId) {
         if (activityId == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.ACTIVITY_INVALID_PARAMS);
         }
 
         // activityId와 deletedAt이 null인 ActivityHistory 레코드 조회

--- a/src/main/java/org/clubs/blueheart/activity/repository/ActivityRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/activity/repository/ActivityRepositoryImpl.java
@@ -32,7 +32,7 @@ public class ActivityRepositoryImpl implements ActivityRepository {
     @Override
     public void createActivity(ActivityCreateRequestDto activityCreateRequestDto) {
         if (activityCreateRequestDto == null) {
-            throw new IllegalArgumentException("ActivityCreateDto is null");
+            throw new RepositoryException(ExceptionStatus.ACTIVITY_INVALID_PARAMS);
         }
 
         User creator = userDao.findById(activityCreateRequestDto.getCreatorId())

--- a/src/main/java/org/clubs/blueheart/activity/repository/ActivityRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/activity/repository/ActivityRepositoryImpl.java
@@ -54,7 +54,7 @@ public class ActivityRepositoryImpl implements ActivityRepository {
     @Override
     public void updateActivityById(ActivityUpdateRequestDto activityUpdateRequestDto) {
         if (activityUpdateRequestDto == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.ACTIVITY_INVALID_PARAMS);
         }
 
         // Fetch the user
@@ -82,7 +82,7 @@ public class ActivityRepositoryImpl implements ActivityRepository {
     @Override
     public List<ActivitySearchResponseDto> findActivityByStatus(ActivityStatus status) {
         if (status == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.ACTIVITY_INVALID_PARAMS);
         }
 
         // Fetch activities by status
@@ -127,7 +127,7 @@ public class ActivityRepositoryImpl implements ActivityRepository {
     @Override
     public ActivityDetailResponseDto findOneActivityDetailById(Long id) {
         if (id == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.ACTIVITY_INVALID_PARAMS);
         }
 
         // Fetch the activity by ID
@@ -153,7 +153,7 @@ public class ActivityRepositoryImpl implements ActivityRepository {
     @Override
     public void deleteActivity(ActivityDeleteRequestDto activityDeleteRequestDto) {
         if (activityDeleteRequestDto == null || activityDeleteRequestDto.getId() == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.ACTIVITY_INVALID_PARAMS);
         }
 
         // Fetch the activity

--- a/src/main/java/org/clubs/blueheart/activity/repository/ActivityRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/activity/repository/ActivityRepositoryImpl.java
@@ -58,12 +58,12 @@ public class ActivityRepositoryImpl implements ActivityRepository {
         }
 
         // Fetch the user
-        Activity existingActivity = activityDao.findActivityByIdAndDeletedAtIsNull(activityUpdateRequestDto.getId())
+        Activity existingActivity = activityDao.findActivityByIdAndDeletedAtIsNull(activityUpdateRequestDto.getActivityId())
                 .orElseThrow(() -> new RepositoryException(ExceptionStatus.USER_NOT_FOUND_USER));
 
         // Update fields using updateFields
         Activity updatedActivity = existingActivity.toBuilder()
-                .id(activityUpdateRequestDto.getId() != null ? activityUpdateRequestDto.getId() : existingActivity.getId())
+                .id(activityUpdateRequestDto.getActivityId() != null ? activityUpdateRequestDto.getActivityId() : existingActivity.getId())
                 .title(activityUpdateRequestDto.getTitle() != null ? activityUpdateRequestDto.getTitle() : existingActivity.getTitle())
                 .status(activityUpdateRequestDto.getStatus() != null ? activityUpdateRequestDto.getStatus() : existingActivity.getStatus())
                 .maxNumber(activityUpdateRequestDto.getMaxNumber() != null ? activityUpdateRequestDto.getMaxNumber() : existingActivity.getMaxNumber())
@@ -92,7 +92,7 @@ public class ActivityRepositoryImpl implements ActivityRepository {
         // Map Activity entities to ActivitySearchDto
         return activityInfo.stream()
                 .<ActivitySearchResponseDto>map(activity -> ActivitySearchResponseDto.builder()
-                        .id(activity.getId())
+                        .activityId(activity.getId())
                         .title(activity.getTitle())
                         .status(activity.getStatus())
                         .isSubscribed(false) // Set this field based on business logic
@@ -112,7 +112,7 @@ public class ActivityRepositoryImpl implements ActivityRepository {
         // Map to ActivitySearchDto
         return activities.stream()
                 .<ActivitySearchResponseDto>map(activity -> ActivitySearchResponseDto.builder()
-                        .id(activity.getId())
+                        .activityId(activity.getId())
                         .title(activity.getTitle())
                         .status(activity.getStatus())
                         .isSubscribed(false) // Set this field based on business logic
@@ -137,7 +137,7 @@ public class ActivityRepositoryImpl implements ActivityRepository {
         // Map to ActivitySearchDto (assuming details can be extended)
         // Map to ActivityDetailDto
         return ActivityDetailResponseDto.builder()
-                .id(activity.getId())
+                .activityId(activity.getId())
                 .title(activity.getTitle())
                 .description(activity.getDescription())
                 .status(activity.getStatus())
@@ -152,12 +152,12 @@ public class ActivityRepositoryImpl implements ActivityRepository {
 
     @Override
     public void deleteActivity(ActivityDeleteRequestDto activityDeleteRequestDto) {
-        if (activityDeleteRequestDto == null || activityDeleteRequestDto.getId() == null) {
+        if (activityDeleteRequestDto == null || activityDeleteRequestDto.getActivityId() == null) {
             throw new RepositoryException(ExceptionStatus.ACTIVITY_INVALID_PARAMS);
         }
 
         // Fetch the activity
-        Activity existingActivity = activityDao.findActivityByIdAndDeletedAtIsNull(activityDeleteRequestDto.getId())
+        Activity existingActivity = activityDao.findActivityByIdAndDeletedAtIsNull(activityDeleteRequestDto.getActivityId())
                 .orElseThrow(() -> new RepositoryException(ExceptionStatus.ACTIVITY_NOT_FOUND));
 
         // Mark as deleted using the builder

--- a/src/main/java/org/clubs/blueheart/auth/api/AuthApi.java
+++ b/src/main/java/org/clubs/blueheart/auth/api/AuthApi.java
@@ -6,7 +6,7 @@ import org.clubs.blueheart.auth.dto.request.AuthInviteAllRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthInviteOneRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthLoginRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthVerifyRequestDto;
-import org.clubs.blueheart.auth.vo.AuthJwtVo;
+import org.clubs.blueheart.auth.dto.response.AuthJwtResponseDto;
 import org.clubs.blueheart.response.GlobalResponseHandler;
 import org.clubs.blueheart.response.ResponseStatus;
 import org.clubs.blueheart.user.domain.UserRole;
@@ -41,9 +41,9 @@ public class AuthApi {
         //TODO: Filter Layer로 변경
         authService.isSessionValid(sessionId);
 
-        AuthJwtVo authJwtVO = authService.loginUserByStudentNumberAndUsername(authLoginRequestDto);
+        AuthJwtResponseDto authJwtResponseDto = authService.loginUserByStudentNumberAndUsername(authLoginRequestDto);
 
-        String finalJwt = authService.createLoginJwt(authJwtVO.getId(), authJwtVO.getStudentNumber(), authJwtVO.getUsername(), authJwtVO.getRole());
+        String finalJwt = authService.createLoginJwt(authJwtResponseDto.getId(), authJwtResponseDto.getStudentNumber(), authJwtResponseDto.getUsername(), authJwtResponseDto.getRole());
 
         // 최종 JWT를 쿠키로 주거나, 바디로 주거나 선택
         ResponseCookie loginCookie = ResponseCookie.from("FINAL_JWT", finalJwt)
@@ -54,7 +54,7 @@ public class AuthApi {
 
         return GlobalResponseHandler.successWithCookie(
                 ResponseStatus.AUTH_LOGGED_IN,
-                authJwtVO.getRole(),
+                authJwtResponseDto.getRole(),
                 loginCookie // toString() 제거
         );
     }

--- a/src/main/java/org/clubs/blueheart/auth/api/AuthApi.java
+++ b/src/main/java/org/clubs/blueheart/auth/api/AuthApi.java
@@ -7,12 +7,14 @@ import org.clubs.blueheart.auth.dto.request.AuthInviteOneRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthLoginRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthVerifyRequestDto;
 import org.clubs.blueheart.auth.dto.response.AuthJwtResponseDto;
+import org.clubs.blueheart.config.ValidationSequenceConfig;
 import org.clubs.blueheart.response.GlobalResponseHandler;
 import org.clubs.blueheart.response.ResponseStatus;
 import org.clubs.blueheart.user.domain.UserRole;
 import org.clubs.blueheart.user.dto.request.UserInfoRequestDto;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -26,7 +28,7 @@ public class AuthApi {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<GlobalResponseHandler<Void>> registerUser(@RequestBody @Valid UserInfoRequestDto userInfoRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> registerUser(@RequestBody @Validated(ValidationSequenceConfig.class) UserInfoRequestDto userInfoRequestDto) {
         authService.registerUser(userInfoRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.AUTH_USER_CREATED);
     }
@@ -61,26 +63,26 @@ public class AuthApi {
 
     //TODO: jwt 토큰 삭제로 변경할 예정
     @PostMapping("/logout")
-    public ResponseEntity<GlobalResponseHandler<Void>> logoutUser(@RequestBody @Valid AuthLoginRequestDto authLoginRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> logoutUser(@RequestBody @Validated(ValidationSequenceConfig.class) AuthLoginRequestDto authLoginRequestDto) {
         authService.logoutUser(authLoginRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.AUTH_LOGGED_OUT);
     }
 
     //TODO: DTO로 변경
     @PostMapping("/invite/all")
-    public ResponseEntity<GlobalResponseHandler<String>> inviteAllUser(@RequestBody @Valid AuthInviteAllRequestDto authInviteAllRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<String>> inviteAllUser(@RequestBody @Validated(ValidationSequenceConfig.class) AuthInviteAllRequestDto authInviteAllRequestDto) {
         String inviteAllUrl = authService.inviteAllUser(authInviteAllRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.AUTH_INVITE_LINK_CREATED, inviteAllUrl);
     }
 
     @PostMapping("/invite")
-    public ResponseEntity<GlobalResponseHandler<String>> inviteUserByStudentNumber(@RequestBody @Valid AuthInviteOneRequestDto authInviteOneDto) {
+    public ResponseEntity<GlobalResponseHandler<String>> inviteUserByStudentNumber(@RequestBody @Validated(ValidationSequenceConfig.class) AuthInviteOneRequestDto authInviteOneDto) {
         String inviteUrl = authService.inviteUserByStudentNumber(authInviteOneDto);
         return GlobalResponseHandler.success(ResponseStatus.AUTH_INVITE_LINK_CREATED, inviteUrl);
     }
 
     @PostMapping("/verify")
-    public ResponseEntity<GlobalResponseHandler<Void>> verifyInviteCode(@RequestBody @Valid AuthVerifyRequestDto authVerifyRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> verifyInviteCode(@RequestBody @Validated(ValidationSequenceConfig.class) AuthVerifyRequestDto authVerifyRequestDto) {
 
         String sessionId = authService.verifyInviteCode(authVerifyRequestDto);
 

--- a/src/main/java/org/clubs/blueheart/auth/api/AuthApi.java
+++ b/src/main/java/org/clubs/blueheart/auth/api/AuthApi.java
@@ -1,6 +1,5 @@
 package org.clubs.blueheart.auth.api;
 
-import jakarta.validation.Valid;
 import org.clubs.blueheart.auth.application.AuthService;
 import org.clubs.blueheart.auth.dto.request.AuthInviteAllRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthInviteOneRequestDto;

--- a/src/main/java/org/clubs/blueheart/auth/api/AuthApi.java
+++ b/src/main/java/org/clubs/blueheart/auth/api/AuthApi.java
@@ -28,12 +28,12 @@ public class AuthApi {
     @PostMapping("/register")
     public ResponseEntity<GlobalResponseHandler<Void>> registerUser(@RequestBody @Valid UserInfoRequestDto userInfoRequestDto) {
         authService.registerUser(userInfoRequestDto);
-        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_CREATED);
+        return GlobalResponseHandler.success(ResponseStatus.AUTH_USER_CREATED);
     }
 
     //TODO: 실제 존재하는 유저의 정보를 반환
     @PostMapping("/login")
-    public ResponseEntity<UserRole> loginUser(
+    public ResponseEntity<GlobalResponseHandler<UserRole>> loginUser(
             @CookieValue(value = "SESSION_ID", required = false) String sessionId,
             @RequestBody AuthLoginRequestDto authLoginRequestDto
     ) {
@@ -52,29 +52,31 @@ public class AuthApi {
                 .path("/")
                 .build();
 
-        return ResponseEntity.ok()
-                .header("Set-Cookie", loginCookie.toString())
-                .body(authJwtVO.getRole());
+        return GlobalResponseHandler.successWithCookie(
+                ResponseStatus.AUTH_LOGGED_IN,
+                authJwtVO.getRole(),
+                loginCookie // toString() 제거
+        );
     }
 
     //TODO: jwt 토큰 삭제로 변경할 예정
     @PostMapping("/logout")
     public ResponseEntity<GlobalResponseHandler<Void>> logoutUser(@RequestBody @Valid AuthLoginRequestDto authLoginRequestDto) {
         authService.logoutUser(authLoginRequestDto);
-        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_CREATED);
+        return GlobalResponseHandler.success(ResponseStatus.AUTH_LOGGED_OUT);
     }
 
     //TODO: DTO로 변경
     @PostMapping("/invite/all")
     public ResponseEntity<GlobalResponseHandler<String>> inviteAllUser(@RequestBody @Valid AuthInviteAllRequestDto authInviteAllRequestDto) {
         String inviteAllUrl = authService.inviteAllUser(authInviteAllRequestDto);
-        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_UPDATED, inviteAllUrl);
+        return GlobalResponseHandler.success(ResponseStatus.AUTH_INVITE_LINK_CREATED, inviteAllUrl);
     }
 
     @PostMapping("/invite")
     public ResponseEntity<GlobalResponseHandler<String>> inviteUserByStudentNumber(@RequestBody @Valid AuthInviteOneRequestDto authInviteOneDto) {
         String inviteUrl = authService.inviteUserByStudentNumber(authInviteOneDto);
-        return GlobalResponseHandler.success(ResponseStatus.ACTIVITY_UPDATED, inviteUrl);
+        return GlobalResponseHandler.success(ResponseStatus.AUTH_INVITE_LINK_CREATED, inviteUrl);
     }
 
     @PostMapping("/verify")
@@ -90,6 +92,6 @@ public class AuthApi {
 
 
         // 3) GlobalResponseHandler 로 쿠키+응답 생성
-        return GlobalResponseHandler.successWithCookie(ResponseStatus.ACTIVITY_UPDATED, cookie);
+        return GlobalResponseHandler.successWithCookie(ResponseStatus.AUTH_VERIFIED, cookie);
     }
 }

--- a/src/main/java/org/clubs/blueheart/auth/application/AuthService.java
+++ b/src/main/java/org/clubs/blueheart/auth/application/AuthService.java
@@ -6,7 +6,7 @@ import org.clubs.blueheart.auth.dto.request.AuthInviteAllRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthInviteOneRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthLoginRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthVerifyRequestDto;
-import org.clubs.blueheart.auth.vo.AuthJwtVo;
+import org.clubs.blueheart.auth.dto.response.AuthJwtResponseDto;
 import org.clubs.blueheart.config.jwt.JwtGenerator;
 import org.clubs.blueheart.exception.ApplicationException;
 import org.clubs.blueheart.exception.ExceptionStatus;
@@ -35,7 +35,7 @@ public class AuthService {
         this.jwtGenerator = jwtGenerator;
     }
 
-    public AuthJwtVo loginUserByStudentNumberAndUsername(AuthLoginRequestDto authLoginRequestDto) {
+    public AuthJwtResponseDto loginUserByStudentNumberAndUsername(AuthLoginRequestDto authLoginRequestDto) {
         return authRepository.findUserByStudentNumberAndUsername(authLoginRequestDto);
     }
 

--- a/src/main/java/org/clubs/blueheart/auth/dao/AuthRepository.java
+++ b/src/main/java/org/clubs/blueheart/auth/dao/AuthRepository.java
@@ -1,8 +1,8 @@
 package org.clubs.blueheart.auth.dao;
 
 import org.clubs.blueheart.auth.dto.request.AuthLoginRequestDto;
-import org.clubs.blueheart.auth.vo.AuthJwtVo;
+import org.clubs.blueheart.auth.dto.response.AuthJwtResponseDto;
 
 public interface AuthRepository {
-    AuthJwtVo findUserByStudentNumberAndUsername(AuthLoginRequestDto authLoginRequestDto);
+    AuthJwtResponseDto findUserByStudentNumberAndUsername(AuthLoginRequestDto authLoginRequestDto);
 }

--- a/src/main/java/org/clubs/blueheart/auth/dao/AuthRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/auth/dao/AuthRepositoryImpl.java
@@ -1,7 +1,7 @@
 package org.clubs.blueheart.auth.dao;
 
 import org.clubs.blueheart.auth.dto.request.AuthLoginRequestDto;
-import org.clubs.blueheart.auth.vo.AuthJwtVo;
+import org.clubs.blueheart.auth.dto.response.AuthJwtResponseDto;
 import org.clubs.blueheart.exception.ExceptionStatus;
 import org.clubs.blueheart.exception.RepositoryException;
 import org.clubs.blueheart.user.dao.UserDao;
@@ -19,7 +19,7 @@ public class AuthRepositoryImpl implements AuthRepository {
     }
 
     @Override
-    public AuthJwtVo findUserByStudentNumberAndUsername(AuthLoginRequestDto authLoginRequestDto) {
+    public AuthJwtResponseDto findUserByStudentNumberAndUsername(AuthLoginRequestDto authLoginRequestDto) {
 
         if (authLoginRequestDto == null) {
             throw new RepositoryException(ExceptionStatus.USER_NOT_FOUND_USER);
@@ -31,7 +31,7 @@ public class AuthRepositoryImpl implements AuthRepository {
 
 
         // 엔티티 -> AuthJwtDto 로 매핑
-        return AuthJwtVo.builder()
+        return AuthJwtResponseDto.builder()
                 .id(user.getId())
                 .studentNumber(user.getStudentNumber())
                 .username(user.getUsername())

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteAllRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteAllRequestDto.java
@@ -3,7 +3,6 @@ package org.clubs.blueheart.auth.dto.request;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Data

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteAllRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteAllRequestDto.java
@@ -1,12 +1,15 @@
 package org.clubs.blueheart.auth.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Data
 @SuperBuilder
-@NoArgsConstructor //TODO: 해결 필요
 public class AuthInviteAllRequestDto {
+    @NotBlank(message = "Creator ID must not be blank")
+    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long creatorId;
 }

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteAllRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteAllRequestDto.java
@@ -6,12 +6,16 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.clubs.blueheart.config.ValidationGroups;
 
 @Data
 @SuperBuilder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthInviteAllRequestDto {
-    @NotNull(message = "Creator ID must not be blank")
-    @Min(value = 1)
+    @NotNull(message = "Creator ID must not be blank",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1,
+            message = "creatorId must be at least 1",
+    groups = ValidationGroups.SizeGroup.class)
     private Long creatorId;
 }

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteAllRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteAllRequestDto.java
@@ -1,14 +1,17 @@
 package org.clubs.blueheart.auth.dto.request;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Data
 @SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthInviteAllRequestDto {
-    @NotBlank(message = "Creator ID must not be blank")
-    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
+    @NotNull(message = "Creator ID must not be blank")
+    @Min(value = 1)
     private Long creatorId;
 }

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteOneRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteOneRequestDto.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Data

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteOneRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteOneRequestDto.java
@@ -15,15 +15,17 @@ import org.clubs.blueheart.config.ValidationGroups;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthInviteOneRequestDto extends AuthInviteAllRequestDto {
 
-    @NotBlank(message = "TargetUsername must not be blank",
+    @NotBlank(message = "Target username must not be blank",
             groups = ValidationGroups.NotBlankGroup.class)
     @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$",
+            message = "Target username can only contain letters",
             groups = ValidationGroups.PatternGroup.class)
     private String targetUsername;
 
-    @NotBlank(message = "TargetStudentNumber must not be blank",
+    @NotBlank(message = "Target student number must not be blank",
             groups = ValidationGroups.NotBlankGroup.class)
     @Pattern(regexp = "^[0-9]+$",
-    groups = ValidationGroups.PatternGroup.class)
+            message = "Target student number must only contain numbers",
+            groups = ValidationGroups.PatternGroup.class)
     private String targetStudentNumber;
 }

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteOneRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteOneRequestDto.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.clubs.blueheart.config.ValidationGroups;
 
 @Data
 @SuperBuilder
@@ -14,11 +15,15 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthInviteOneRequestDto extends AuthInviteAllRequestDto {
 
-    @NotBlank(message = "TargetUsername must not be blank")
-    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
+    @NotBlank(message = "TargetUsername must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$",
+            groups = ValidationGroups.PatternGroup.class)
     private String targetUsername;
 
-    @NotBlank(message = "TargetStudentNumber must not be blank")
-    @Pattern(regexp = "^[0-9]+$")
+    @NotBlank(message = "TargetStudentNumber must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[0-9]+$",
+    groups = ValidationGroups.PatternGroup.class)
     private String targetStudentNumber;
 }

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteOneRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteOneRequestDto.java
@@ -2,13 +2,16 @@ package org.clubs.blueheart.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Data
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthInviteOneRequestDto extends AuthInviteAllRequestDto {
 
     @NotBlank(message = "TargetUsername must not be blank")

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteOneRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthInviteOneRequestDto.java
@@ -1,5 +1,7 @@
 package org.clubs.blueheart.auth.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
@@ -8,10 +10,13 @@ import lombok.experimental.SuperBuilder;
 @Data
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)
-@NoArgsConstructor //TODO: 해결 필요
 public class AuthInviteOneRequestDto extends AuthInviteAllRequestDto {
 
+    @NotBlank(message = "TargetUsername must not be blank")
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
     private String targetUsername;
 
+    @NotBlank(message = "TargetStudentNumber must not be blank")
+    @Pattern(regexp = "^[0-9]+$")
     private String targetStudentNumber;
 }

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthLoginRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthLoginRequestDto.java
@@ -4,15 +4,20 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 
 @Data
 @Builder
 public class AuthLoginRequestDto {
-    @NotBlank(message = "Username must not be blank")
-    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
+    @NotBlank(message = "Username must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$",
+            groups = ValidationGroups.PatternGroup.class)
     private String username;
 
-    @NotBlank(message = "StudentNumber must not be blank")
-    @Pattern(regexp = "^[0-9]+$")
+    @NotBlank(message = "StudentNumber must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[0-9]+$",
+            groups = ValidationGroups.PatternGroup.class)
     private String studentNumber;
 }

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthLoginRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthLoginRequestDto.java
@@ -1,7 +1,6 @@
 package org.clubs.blueheart.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthLoginRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthLoginRequestDto.java
@@ -9,15 +9,18 @@ import org.clubs.blueheart.config.ValidationGroups;
 @Data
 @Builder
 public class AuthLoginRequestDto {
+
     @NotBlank(message = "Username must not be blank",
             groups = ValidationGroups.NotBlankGroup.class)
     @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$",
+            message = "Username can only contain letters",
             groups = ValidationGroups.PatternGroup.class)
     private String username;
 
-    @NotBlank(message = "StudentNumber must not be blank",
+    @NotBlank(message = "Student number must not be blank",
             groups = ValidationGroups.NotBlankGroup.class)
     @Pattern(regexp = "^[0-9]+$",
+            message = "Student number must only contain numbers",
             groups = ValidationGroups.PatternGroup.class)
     private String studentNumber;
 }

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthLoginRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthLoginRequestDto.java
@@ -2,6 +2,7 @@ package org.clubs.blueheart.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
 
@@ -9,8 +10,10 @@ import lombok.Data;
 @Builder
 public class AuthLoginRequestDto {
     @NotBlank(message = "Username must not be blank")
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
     private String username;
 
-    @NotNull(message = "Student number must not be null")
+    @NotBlank(message = "StudentNumber must not be blank")
+    @Pattern(regexp = "^[0-9]+$")
     private String studentNumber;
 }

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthVerifyRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthVerifyRequestDto.java
@@ -1,10 +1,14 @@
 package org.clubs.blueheart.auth.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
 
 @Builder
 @Data
 public class AuthVerifyRequestDto {
+    @NotBlank(message = "TargetStudentNumber must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$")
     private String code;
 }

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthVerifyRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthVerifyRequestDto.java
@@ -4,11 +4,14 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 
 @Builder
 @Data
 public class AuthVerifyRequestDto {
-    @NotBlank(message = "TargetStudentNumber must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$")
+    @NotBlank(message = "TargetStudentNumber must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            groups = ValidationGroups.PatternGroup.class)
     private String code;
 }

--- a/src/main/java/org/clubs/blueheart/auth/dto/request/AuthVerifyRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/request/AuthVerifyRequestDto.java
@@ -9,9 +9,11 @@ import org.clubs.blueheart.config.ValidationGroups;
 @Builder
 @Data
 public class AuthVerifyRequestDto {
-    @NotBlank(message = "TargetStudentNumber must not be blank",
+
+    @NotBlank(message = "Verification code must not be blank",
             groups = ValidationGroups.NotBlankGroup.class)
     @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Verification code can only contain letters, numbers, and symbols",
             groups = ValidationGroups.PatternGroup.class)
     private String code;
 }

--- a/src/main/java/org/clubs/blueheart/auth/dto/response/AuthJwtResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/response/AuthJwtResponseDto.java
@@ -1,4 +1,4 @@
-package org.clubs.blueheart.auth.vo;
+package org.clubs.blueheart.auth.dto.response;
 
 import lombok.Builder;
 import lombok.Data;
@@ -7,7 +7,7 @@ import org.clubs.blueheart.user.domain.UserRole;
 //TODO: 추후에 VO로 변형도 생각해보기
 @Builder
 @Data
-public class AuthJwtVo {
+public class AuthJwtResponseDto {
 
     private Long id;
 

--- a/src/main/java/org/clubs/blueheart/auth/dto/response/AuthJwtResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/response/AuthJwtResponseDto.java
@@ -1,7 +1,11 @@
 package org.clubs.blueheart.auth.dto.response;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 import org.clubs.blueheart.user.domain.UserRole;
 
 //TODO: 추후에 VO로 변형도 생각해보기
@@ -9,11 +13,22 @@ import org.clubs.blueheart.user.domain.UserRole;
 @Data
 public class AuthJwtResponseDto {
 
+    @Min(value = 1,
+            groups = ValidationGroups.SizeGroup.class)
     private Long id;
 
+    @NotBlank(message = "StudentNumber must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[0-9]+$",
+            groups = ValidationGroups.PatternGroup.class)
     private String studentNumber;
 
+    @NotBlank(message = "Username must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$",
+            groups = ValidationGroups.PatternGroup.class)
     private String username;
+
 
     private UserRole role;
 

--- a/src/main/java/org/clubs/blueheart/auth/dto/response/AuthJwtResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/auth/dto/response/AuthJwtResponseDto.java
@@ -2,6 +2,7 @@ package org.clubs.blueheart.auth.dto.response;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
@@ -13,23 +14,26 @@ import org.clubs.blueheart.user.domain.UserRole;
 @Data
 public class AuthJwtResponseDto {
 
-    @Min(value = 1,
+    @Min(value = 1, message = "User ID must be at least 1",
             groups = ValidationGroups.SizeGroup.class)
     private Long id;
 
     @NotBlank(message = "StudentNumber must not be blank",
             groups = ValidationGroups.NotBlankGroup.class)
     @Pattern(regexp = "^[0-9]+$",
+            message = "StudentNumber can only contain numbers",
             groups = ValidationGroups.PatternGroup.class)
     private String studentNumber;
 
     @NotBlank(message = "Username must not be blank",
             groups = ValidationGroups.NotBlankGroup.class)
     @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$",
+            message = "Username can only contain letters",
             groups = ValidationGroups.PatternGroup.class)
     private String username;
 
-
+    @NotNull(message = "Role must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
     private UserRole role;
 
 }

--- a/src/main/java/org/clubs/blueheart/config/SecurityConfig.java
+++ b/src/main/java/org/clubs/blueheart/config/SecurityConfig.java
@@ -26,9 +26,9 @@ public class SecurityConfig {
                 )
                 // CSRF 비활성화 (모든 경로)
                 .csrf(csrf -> csrf.disable())
-                .exceptionHandling()
-                    .authenticationEntryPoint(customAuthenticationEntryPoint)
-                .and()
+                .exceptionHandling((exceptionConfig) ->
+                        exceptionConfig.authenticationEntryPoint(customAuthenticationEntryPoint)
+                )
                 // H2 콘솔을 위한 헤더 설정
                 .headers(headers ->
                         headers.frameOptions(frameOptions -> frameOptions.sameOrigin())

--- a/src/main/java/org/clubs/blueheart/config/SecurityConfig.java
+++ b/src/main/java/org/clubs/blueheart/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package org.clubs.blueheart.config;
 
 import org.clubs.blueheart.config.jwt.JwtCookieFilter;
 import lombok.RequiredArgsConstructor;
+import org.clubs.blueheart.exception.CustomAuthenticationEntryPoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -14,6 +15,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtCookieFilter jwtCookieFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -24,6 +26,9 @@ public class SecurityConfig {
                 )
                 // CSRF 비활성화 (모든 경로)
                 .csrf(csrf -> csrf.disable())
+                .exceptionHandling()
+                    .authenticationEntryPoint(customAuthenticationEntryPoint)
+                .and()
                 // H2 콘솔을 위한 헤더 설정
                 .headers(headers ->
                         headers.frameOptions(frameOptions -> frameOptions.sameOrigin())

--- a/src/main/java/org/clubs/blueheart/config/SecurityConfig.java
+++ b/src/main/java/org/clubs/blueheart/config/SecurityConfig.java
@@ -35,13 +35,13 @@ public class SecurityConfig {
                 )
                 // 권한 설정
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/auth/register").permitAll()  // 사용자 등록
+                        .requestMatchers("/api/v1/auth/login").permitAll()     // 로그인
+                        .requestMatchers("/api/v1/auth/verify").permitAll()    // 초대 코드 검증
+
                         .requestMatchers("/h2-console/**").permitAll()
-                        .requestMatchers("/swagger-ui/**").permitAll()
-                        .requestMatchers("/v3/api-docs/**").permitAll()
-                        .requestMatchers("/swagger-resources/**").permitAll()
-                        .requestMatchers("/swagger-ui.html").permitAll()
-                        .requestMatchers("/webjars/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/swagger-ui.html", "/webjars/**").permitAll()
+
                         .anyRequest().authenticated()
                 )
                 // JWT 필터 추가

--- a/src/main/java/org/clubs/blueheart/config/ValidationGroups.java
+++ b/src/main/java/org/clubs/blueheart/config/ValidationGroups.java
@@ -1,0 +1,9 @@
+package org.clubs.blueheart.config;
+
+public class ValidationGroups {
+    public interface NotNullGroup {}
+    public interface NotBlankGroup {}
+    public interface PatternGroup {}
+    public interface SizeGroup {}
+    public interface DateTimeGroup {}
+}

--- a/src/main/java/org/clubs/blueheart/config/ValidationSequenceConfig.java
+++ b/src/main/java/org/clubs/blueheart/config/ValidationSequenceConfig.java
@@ -1,0 +1,8 @@
+package org.clubs.blueheart.config;
+
+import jakarta.validation.GroupSequence;
+
+@GroupSequence({ValidationGroups.NotNullGroup.class, ValidationGroups.NotBlankGroup.class, ValidationGroups.PatternGroup.class, ValidationGroups.SizeGroup.class, ValidationGroups.DateTimeGroup.class})
+public interface ValidationSequenceConfig {
+}
+

--- a/src/main/java/org/clubs/blueheart/config/jwt/JwtCookieFilter.java
+++ b/src/main/java/org/clubs/blueheart/config/jwt/JwtCookieFilter.java
@@ -35,7 +35,9 @@ public class JwtCookieFilter extends OncePerRequestFilter {
         String path = request.getRequestURI();
 
         // /api/v1/auth/**, /h2-console/**, Swagger 관련 경로 제외
-        if (path.startsWith("/api/v1/auth/")
+        if (path.startsWith("/api/v1/auth/register")
+                || path.startsWith("/api/v1/auth/login")
+                || path.startsWith("/api/v1/auth/verify")
                 || path.startsWith("/h2-console/")
                 || path.startsWith("/swagger")
                 || path.startsWith("/v3/api-docs")

--- a/src/main/java/org/clubs/blueheart/config/jwt/JwtCookieFilter.java
+++ b/src/main/java/org/clubs/blueheart/config/jwt/JwtCookieFilter.java
@@ -1,5 +1,6 @@
 package org.clubs.blueheart.config.jwt;
 
+import io.jsonwebtoken.MalformedJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -69,9 +70,10 @@ public class JwtCookieFilter extends OncePerRequestFilter {
                                     userDetails.getAuthorities()
                             );
                     SecurityContextHolder.getContext().setAuthentication(authentication);
-                } else {
-                    throw new MiddlewareException(ExceptionStatus.GENERAL_INTERNAL_SERVER_ERROR);
                 }
+
+            } catch (MalformedJwtException e) {
+                throw new MiddlewareException(ExceptionStatus.GENERAL_INTERNAL_SERVER_ERROR);
             } catch (JwtException e) {
                 throw new MiddlewareException(ExceptionStatus.GENERAL_INTERNAL_SERVER_ERROR);
             }

--- a/src/main/java/org/clubs/blueheart/config/jwt/JwtCookieFilter.java
+++ b/src/main/java/org/clubs/blueheart/config/jwt/JwtCookieFilter.java
@@ -51,7 +51,7 @@ public class JwtCookieFilter extends OncePerRequestFilter {
                     Claims claims = jwtProvider.getClaims(jwt);
                     Long userId = claims.get("userId", Long.class);
                     if (userId == null) {
-                        throw new MiddlewareException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+                        throw new MiddlewareException(ExceptionStatus.GENERAL_BAD_REQUEST);
                     }
 
                     String username = claims.get("username", String.class);

--- a/src/main/java/org/clubs/blueheart/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/clubs/blueheart/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,40 @@
+package org.clubs.blueheart.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public CustomAuthenticationEntryPoint(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        // 로그 기록
+        // 이곳에 로그를 추가할 수도 있습니다.
+
+        CustomExceptionStatus errorResponse = new CustomExceptionStatus(
+                ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED,
+                ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getMessage()
+        );
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getStatusCode());
+
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/org/clubs/blueheart/exception/CustomExceptionStatus.java
+++ b/src/main/java/org/clubs/blueheart/exception/CustomExceptionStatus.java
@@ -23,7 +23,7 @@ public class CustomExceptionStatus {
 
     public CustomExceptionStatus(ExceptionStatus status, String message) {
         this.statusCode = status.getStatusCode();
-        this.message = status.getMessage() + "\n해제 날짜 : " + message;
+        this.message = message;
         this.error = status.getError();
     }
 }

--- a/src/main/java/org/clubs/blueheart/exception/ExceptionStatus.java
+++ b/src/main/java/org/clubs/blueheart/exception/ExceptionStatus.java
@@ -184,9 +184,9 @@ public enum ExceptionStatus {
 //    public UtilException asUtilException() {
 //        return new UtilException(this);
 //    }
-
-    public MiddlewareException asMiddlewareException() {
-        return new MiddlewareException(this);
-    }
+//
+//    public MiddlewareException asMiddlewareException() {
+//        return new MiddlewareException(this);
+//    }
 }
 

--- a/src/main/java/org/clubs/blueheart/exception/ExceptionStatus.java
+++ b/src/main/java/org/clubs/blueheart/exception/ExceptionStatus.java
@@ -15,6 +15,8 @@ public enum ExceptionStatus {
     AUTH_BAD_SESSION_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 세션으로 인한 요청 방법입니다."),
     AUTH_COOKIE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "잘못된 쿠키로 접근했습니다"),
     AUTH_SESSION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "잘못된 세션으로 접근했습니다"),
+    AUTH_INVALID_INVITE_CODE(HttpStatus.BAD_REQUEST, "잘못된 초대 코드로 요청했습니다"),
+
 
     // USER ERROR CODE
     USER_NOT_FOUND_ADMIN(HttpStatus.NOT_FOUND, "어드민이 존재하지 않습니다"),

--- a/src/main/java/org/clubs/blueheart/exception/ExceptionStatus.java
+++ b/src/main/java/org/clubs/blueheart/exception/ExceptionStatus.java
@@ -13,8 +13,8 @@ public enum ExceptionStatus {
     // AUTH ERROR CODE
     AUTH_INVALID_PARAMS(HttpStatus.BAD_REQUEST, "잘못된 인자로 요청했습니다"),
     AUTH_BAD_SESSION_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 세션으로 인한 요청 방법입니다."),
-    AUTH_COOKIE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "잘못된 쿠키로 접근했습니다!"),
-    AUTH_SESSION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "잘못된 세션으로 접근했습니다!"),
+    AUTH_COOKIE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "잘못된 쿠키로 접근했습니다"),
+    AUTH_SESSION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "잘못된 세션으로 접근했습니다"),
 
     // USER ERROR CODE
     USER_NOT_FOUND_ADMIN(HttpStatus.NOT_FOUND, "어드민이 존재하지 않습니다"),
@@ -63,6 +63,7 @@ public enum ExceptionStatus {
 
     // GENERAL ERROR CODE
     GENERAL_BAD_REQUEST(HttpStatus.BAD_REQUEST, "서버에 잘못된 요청입니다."),
+    GENERAL_REQUEST_INVALID_PARAMS(HttpStatus.BAD_REQUEST, "서버에 잘못된 요청입니다."),
 
     GENERAL_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 알 수 없는 오류가 발생했습니다"),
     GENERAL_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "서버가 작동하지 않고 있습니다."),

--- a/src/main/java/org/clubs/blueheart/exception/ExceptionStatus.java
+++ b/src/main/java/org/clubs/blueheart/exception/ExceptionStatus.java
@@ -11,7 +11,9 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionStatus {
 
     // AUTH ERROR CODE
-    AUTH_BAD_SESSION_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청 방법입니다."),
+    AUTH_INVALID_PARAMS(HttpStatus.BAD_REQUEST, "잘못된 인자로 요청했습니다"),
+    AUTH_BAD_SESSION_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 세션으로 인한 요청 방법입니다."),
+    AUTH_COOKIE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "잘못된 쿠키로 접근했습니다!"),
     AUTH_SESSION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "잘못된 세션으로 접근했습니다!"),
 
     // USER ERROR CODE
@@ -20,7 +22,7 @@ public enum ExceptionStatus {
     USER_NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다"),
 
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 유저입니다"),
-    USER_INVALID_USER_INPUT(HttpStatus.BAD_REQUEST, "잘못된 사용자 입력입니다"),
+    USER_INVALID_PARAMS(HttpStatus.BAD_REQUEST, "잘못된 사용자 입력입니다"),
     USER_UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "사용자 인증이 유효하지 않습니다"),
 
     USER_INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, "검색 키워드가 유효하지 않습니다"),
@@ -30,7 +32,7 @@ public enum ExceptionStatus {
     // ACTIVITY ERROR CODE
     ACTIVITY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 액티비티입니다"),
     ACTIVITY_NOT_FOUND(HttpStatus.NOT_FOUND, "액티비티를 찾을 수 없습니다"),
-    ACTIVITY_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 액티비티 요청입니다"),
+    ACTIVITY_INVALID_PARAMS(HttpStatus.BAD_REQUEST, "유효하지 않은 액티비티 요청입니다"),
     ACTIVITY_UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "액티비티 접근 권한이 없습니다"),
     ACTIVITY_UPDATE_FAILED(HttpStatus.BAD_REQUEST, "액티비티 업데이트 실패"),
     ACTIVITY_DELETE_FAILED(HttpStatus.BAD_REQUEST, "액티비티 삭제 실패"),
@@ -56,12 +58,18 @@ public enum ExceptionStatus {
     // NOTIFICATION ERROR CODE
     NOTIFICATION_SEND_FAILED(HttpStatus.BAD_REQUEST, "알림 전송 실패"),
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다"),
-    NOTIFICATION_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "유효하지 않은 알림 요청입니다"),
+    NOTIFICATION_INVALID_PARAMS(HttpStatus.BAD_REQUEST, "유효하지 않은 알림 요청입니다"),
     NOTIFICATION_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "알림의 대상 사용자를 찾을 수 없습니다"),
 
     // GENERAL ERROR CODE
+    GENERAL_BAD_REQUEST(HttpStatus.BAD_REQUEST, "서버에 잘못된 요청입니다."),
+
     GENERAL_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 알 수 없는 오류가 발생했습니다"),
-    GENERAL_INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "잘못된 인자롤 통한 요청입니다.");
+    GENERAL_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "서버가 작동하지 않고 있습니다."),
+    GENERAL_GATEWAY_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "서버에서 타임아웃이 발생했습니다");
+
+
+
 
     //    NOT_FOUND_LENT_HISTORY(HttpStatus.NOT_FOUND, "대여한 사물함이 존재하지 않습니다."),
 //    NOT_FOUND_CLUB(HttpStatus.NOT_FOUND, "동아리가 존재하지 않습니다."),

--- a/src/main/java/org/clubs/blueheart/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/clubs/blueheart/exception/GlobalExceptionHandler.java
@@ -1,27 +1,34 @@
 package org.clubs.blueheart.exception;
 
-import org.clubs.blueheart.activity.domain.Activity;
-import org.clubs.blueheart.activity.domain.ActivityHistory;
-import org.clubs.blueheart.auth.api.AuthApi;
-import org.clubs.blueheart.group.api.GroupApi;
-import org.clubs.blueheart.notification.domain.Notification;
-import org.clubs.blueheart.user.api.UserApi;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import jakarta.validation.ConstraintViolationException;
+
+import java.util.stream.Collectors;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Global exception handler to manage all exceptions across the application.
+ */
 @RestControllerAdvice
-public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+@Slf4j
+public class GlobalExceptionHandler {
 
     /**
      * Handle ApiException
      */
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<CustomExceptionStatus> handleApiException(ApiException ex, WebRequest request) {
+        log.error("ApiException: {}", ex.getMessage(), ex);
         return buildErrorResponse(ex.getStatus(), request);
     }
 
@@ -30,6 +37,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(ApplicationException.class)
     public ResponseEntity<CustomExceptionStatus> handleApplicationException(ApplicationException ex, WebRequest request) {
+        log.error("ApplicationException: {}", ex.getMessage(), ex);
         return buildErrorResponse(ex.getStatus(), request);
     }
 
@@ -38,13 +46,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(DaoException.class)
     public ResponseEntity<CustomExceptionStatus> handleDaoException(DaoException ex, WebRequest request) {
+        log.error("DaoException: {}", ex.getMessage(), ex);
         return buildErrorResponse(ex.getStatus(), request);
+    }
 
-    }/**
+    /**
      * Handle DtoException
      */
     @ExceptionHandler(DtoException.class)
     public ResponseEntity<CustomExceptionStatus> handleDtoException(DtoException ex, WebRequest request) {
+        log.error("DtoException: {}", ex.getMessage(), ex);
         return buildErrorResponse(ex.getStatus(), request);
     }
 
@@ -53,6 +64,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(DomainException.class)
     public ResponseEntity<CustomExceptionStatus> handleDomainException(DomainException ex, WebRequest request) {
+        log.error("DomainException: {}", ex.getMessage(), ex);
         return buildErrorResponse(ex.getStatus(), request);
     }
 
@@ -61,6 +73,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(RepositoryException.class)
     public ResponseEntity<CustomExceptionStatus> handleRepositoryException(RepositoryException ex, WebRequest request) {
+        log.error("RepositoryException: {}", ex.getMessage(), ex);
         return buildErrorResponse(ex.getStatus(), request);
     }
 
@@ -69,6 +82,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(UtilException.class)
     public ResponseEntity<CustomExceptionStatus> handleUtilException(UtilException ex, WebRequest request) {
+        log.error("UtilException: {}", ex.getMessage(), ex);
         return buildErrorResponse(ex.getStatus(), request);
     }
 
@@ -77,7 +91,68 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(MiddlewareException.class)
     public ResponseEntity<CustomExceptionStatus> handleMiddlewareException(MiddlewareException ex, WebRequest request) {
+        log.error("MiddlewareException: {}", ex.getMessage(), ex);
         return buildErrorResponse(ex.getStatus(), request);
+    }
+
+    /**
+     * Handle MethodArgumentNotValidException (DTO 검증 실패)
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CustomExceptionStatus> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex, WebRequest request) {
+        log.error("MethodArgumentNotValidException: {}", ex.getMessage(), ex);
+
+        // 필드별 오류 메시지를 "field: message" 형태로 결합
+        String fieldErrors = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .collect(Collectors.joining("; "));
+
+        // CustomExceptionStatus 객체 생성
+        CustomExceptionStatus errorResponse = new CustomExceptionStatus(
+                ExceptionStatus.GENERAL_REQUEST_INVALID_PARAMS,
+                fieldErrors
+        );
+
+        return ResponseEntity.status(ExceptionStatus.GENERAL_REQUEST_INVALID_PARAMS.getStatusCode()).body(errorResponse);
+    }
+
+    /**
+     * Handle ConstraintViolationException (경로 변수, 요청 파라미터 검증 실패)
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<CustomExceptionStatus> handleConstraintViolationException(ConstraintViolationException ex, WebRequest request) {
+        log.error("ConstraintViolationException: {}", ex.getMessage(), ex);
+
+        String violations = ex.getConstraintViolations()
+                .stream()
+                .map(violation -> violation.getPropertyPath() + ": " + violation.getMessage())
+                .collect(Collectors.joining("; "));
+
+        CustomExceptionStatus errorResponse = new CustomExceptionStatus(
+                ExceptionStatus.GENERAL_REQUEST_INVALID_PARAMS,
+                violations
+        );
+
+        return ResponseEntity.status(ExceptionStatus.GENERAL_REQUEST_INVALID_PARAMS.getStatusCode()).body(errorResponse);
+    }
+
+    /**
+     * Handle MethodArgumentTypeMismatchException (예: 잘못된 Enum 값)
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<CustomExceptionStatus> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException ex, WebRequest request) {
+        log.error("MethodArgumentTypeMismatchException: {}", ex.getMessage(), ex);
+
+        String message = ExceptionStatus.GENERAL_REQUEST_INVALID_PARAMS.getMessage();
+
+        CustomExceptionStatus errorResponse = new CustomExceptionStatus(
+                ExceptionStatus.GENERAL_REQUEST_INVALID_PARAMS,
+                message
+        );
+
+        return ResponseEntity.status(ExceptionStatus.GENERAL_REQUEST_INVALID_PARAMS.getStatusCode()).body(errorResponse);
     }
 
     /**
@@ -85,21 +160,21 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<CustomExceptionStatus> handleGenericException(Exception ex, WebRequest request) {
+        log.error("Unhandled Exception: {}", ex.getMessage(), ex);
         CustomExceptionStatus errorResponse = new CustomExceptionStatus(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                ex.getMessage()
+                ExceptionStatus.GENERAL_INTERNAL_SERVER_ERROR,
+                "서버에서 알 수 없는 오류가 발생했습니다."
         );
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+        return ResponseEntity.status(ExceptionStatus.GENERAL_INTERNAL_SERVER_ERROR.getStatusCode()).body(errorResponse);
     }
 
     /**
-     * Build the error response
+     * Build the error response based on ExceptionStatus
      */
     private ResponseEntity<CustomExceptionStatus> buildErrorResponse(ExceptionStatus errorCode, WebRequest request) {
         CustomExceptionStatus errorResponse = new CustomExceptionStatus(
-                errorCode.getStatusCode(),
-                errorCode.getMessage(),
-                errorCode.getError()
+                errorCode,
+                errorCode.getMessage()
         );
         return ResponseEntity.status(errorCode.getStatusCode()).body(errorResponse);
     }

--- a/src/main/java/org/clubs/blueheart/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/clubs/blueheart/exception/GlobalExceptionHandler.java
@@ -1,9 +1,6 @@
 package org.clubs.blueheart.exception;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;

--- a/src/main/java/org/clubs/blueheart/group/api/GroupApi.java
+++ b/src/main/java/org/clubs/blueheart/group/api/GroupApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.clubs.blueheart.config.ValidationSequenceConfig;
 import org.clubs.blueheart.config.jwt.JwtUserDetails;
 import org.clubs.blueheart.group.application.GroupService;
 import org.clubs.blueheart.group.dto.request.GroupUserRequestDto;
@@ -15,6 +16,7 @@ import org.clubs.blueheart.response.GlobalResponseHandler;
 import org.clubs.blueheart.response.ResponseStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -49,7 +51,7 @@ public class GroupApi {
             )
     })
     @PostMapping("/create")
-    public ResponseEntity<GlobalResponseHandler<Void>> createGroup(@RequestBody @Valid GroupInfoRequestDto groupInfoRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> createGroup(@RequestBody @Validated(ValidationSequenceConfig.class) GroupInfoRequestDto groupInfoRequestDto) {
         groupService.createGroup(groupInfoRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.GROUP_CREATED);
     }
@@ -75,7 +77,7 @@ public class GroupApi {
             )
     })
     @DeleteMapping("/delete")
-    public ResponseEntity<GlobalResponseHandler<Void>> deleteGroup(@RequestBody @Valid GroupInfoRequestDto groupInfoRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> deleteGroup(@RequestBody @Validated(ValidationSequenceConfig.class) GroupInfoRequestDto groupInfoRequestDto) {
         groupService.deleteGroup(groupInfoRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.GROUP_DELETED);
     }
@@ -101,7 +103,7 @@ public class GroupApi {
     })
     //TODO: jwt로 groupId 대체 예정
     @PostMapping("/add")
-    public ResponseEntity<GlobalResponseHandler<Void>> addGroupUser(@RequestBody @Valid GroupUserRequestDto groupUserRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> addGroupUser(@RequestBody @Validated(ValidationSequenceConfig.class) GroupUserRequestDto groupUserRequestDto) {
         groupService.addGroupUserById(groupUserRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.GROUP_ADD);
     }
@@ -126,7 +128,7 @@ public class GroupApi {
             )
     })
     @DeleteMapping("/remove")
-    public ResponseEntity<GlobalResponseHandler<Void>> removeGroupUser(@RequestBody @Valid GroupUserRequestDto groupUserRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> removeGroupUser(@RequestBody @Validated(ValidationSequenceConfig.class) GroupUserRequestDto groupUserRequestDto) {
         groupService.removeGroupUserById(groupUserRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.GROUP_REMOVE);
     }

--- a/src/main/java/org/clubs/blueheart/group/api/GroupApi.java
+++ b/src/main/java/org/clubs/blueheart/group/api/GroupApi.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Valid;
 import org.clubs.blueheart.config.ValidationSequenceConfig;
 import org.clubs.blueheart.config.jwt.JwtUserDetails;
 import org.clubs.blueheart.group.application.GroupService;

--- a/src/main/java/org/clubs/blueheart/group/api/GroupApi.java
+++ b/src/main/java/org/clubs/blueheart/group/api/GroupApi.java
@@ -161,7 +161,7 @@ public class GroupApi {
         System.out.println(userId);
 
         // 2) 기존 로직: userId 기반으로 DB 조회
-        List<GroupUserInfoResponseDto> groupUserInfo = groupService.getMyGroupInfoById(userId);
+        List<GroupUserInfoResponseDto> groupUserInfo = groupService.getMyGroupInfoByUserId(userId);
 
         // 3) 응답
         return GlobalResponseHandler.success(ResponseStatus.GROUP_SEARCHED, groupUserInfo);

--- a/src/main/java/org/clubs/blueheart/group/application/GroupService.java
+++ b/src/main/java/org/clubs/blueheart/group/application/GroupService.java
@@ -34,7 +34,7 @@ public class GroupService {
         groupRepository.removeGroupUserById(groupUserRequestDto);
     }
 
-    public List<GroupUserInfoResponseDto> getMyGroupInfoById(Long id) {
-        return groupRepository.getMyGroupInfoById(id);
+    public List<GroupUserInfoResponseDto> getMyGroupInfoByUserId(Long id) {
+        return groupRepository.getMyGroupInfoByUserId(id);
     }
 }

--- a/src/main/java/org/clubs/blueheart/group/dto/request/GroupInfoRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/group/dto/request/GroupInfoRequestDto.java
@@ -2,6 +2,7 @@ package org.clubs.blueheart.group.dto.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
@@ -10,7 +11,7 @@ import lombok.Data;
 @Builder
 public class GroupInfoRequestDto {
 
-    @NotBlank(message = "UserID must not be blank")
+    @NotNull(message = "UserID must not be blank")
     @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 

--- a/src/main/java/org/clubs/blueheart/group/dto/request/GroupInfoRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/group/dto/request/GroupInfoRequestDto.java
@@ -1,6 +1,8 @@
 package org.clubs.blueheart.group.dto.request;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
 
@@ -8,10 +10,12 @@ import lombok.Data;
 @Builder
 public class GroupInfoRequestDto {
 
-    @NotBlank(message = "userId must not be blank")
+    @NotBlank(message = "UserID must not be blank")
+    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 
     @NotBlank(message = "Username must not be blank")
-    private String name;
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
+    private String username;
 
 }

--- a/src/main/java/org/clubs/blueheart/group/dto/request/GroupInfoRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/group/dto/request/GroupInfoRequestDto.java
@@ -11,7 +11,7 @@ import lombok.Data;
 @Builder
 public class GroupInfoRequestDto {
 
-    @NotNull(message = "UserID must not be blank")
+    @NotNull(message = "UserID must not be null")
     @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 

--- a/src/main/java/org/clubs/blueheart/group/dto/request/GroupInfoRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/group/dto/request/GroupInfoRequestDto.java
@@ -6,17 +6,22 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 
 @Data
 @Builder
 public class GroupInfoRequestDto {
 
-    @NotNull(message = "UserID must not be null")
-    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
+    @NotNull(message = "User ID must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "User ID must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long userId;
 
-    @NotBlank(message = "Username must not be blank")
-    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
+    @NotBlank(message = "Username must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$",
+            message = "Username can only contain letters",
+            groups = ValidationGroups.PatternGroup.class)
     private String username;
-
 }

--- a/src/main/java/org/clubs/blueheart/group/dto/request/GroupUserRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/group/dto/request/GroupUserRequestDto.java
@@ -1,18 +1,18 @@
 package org.clubs.blueheart.group.dto.request;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
 public class GroupUserRequestDto {
-    @NotBlank(message = "UserID must not be blank")
+    @NotNull(message = "UserID must not be blank")
     @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 
-    @NotBlank(message = "GroupId must not be blank")
+    @NotNull(message = "GroupId must not be blank")
     @Min(value = 1, message = "그룹ID는 1이상이어야합니다.")
     private Long groupId;
 }

--- a/src/main/java/org/clubs/blueheart/group/dto/request/GroupUserRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/group/dto/request/GroupUserRequestDto.java
@@ -4,15 +4,21 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 
 @Data
 @Builder
 public class GroupUserRequestDto {
-    @NotNull(message = "UserID must not be null")
-    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
+
+    @NotNull(message = "User ID must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "User ID must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long userId;
 
-    @NotNull(message = "GroupId must not be null")
-    @Min(value = 1, message = "그룹ID는 1이상이어야합니다.")
+    @NotNull(message = "Group ID must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "Group ID must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long groupId;
 }

--- a/src/main/java/org/clubs/blueheart/group/dto/request/GroupUserRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/group/dto/request/GroupUserRequestDto.java
@@ -1,12 +1,18 @@
 package org.clubs.blueheart.group.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
 public class GroupUserRequestDto {
+    @NotBlank(message = "UserID must not be blank")
+    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 
-    private Long GroupId;
+    @NotBlank(message = "GroupId must not be blank")
+    @Min(value = 1, message = "그룹ID는 1이상이어야합니다.")
+    private Long groupId;
 }

--- a/src/main/java/org/clubs/blueheart/group/dto/request/GroupUserRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/group/dto/request/GroupUserRequestDto.java
@@ -8,11 +8,11 @@ import lombok.Data;
 @Data
 @Builder
 public class GroupUserRequestDto {
-    @NotNull(message = "UserID must not be blank")
+    @NotNull(message = "UserID must not be null")
     @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 
-    @NotNull(message = "GroupId must not be blank")
+    @NotNull(message = "GroupId must not be null")
     @Min(value = 1, message = "그룹ID는 1이상이어야합니다.")
     private Long groupId;
 }

--- a/src/main/java/org/clubs/blueheart/group/dto/response/GroupUserInfoResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/group/dto/response/GroupUserInfoResponseDto.java
@@ -1,6 +1,8 @@
 package org.clubs.blueheart.group.dto.response;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
 import org.clubs.blueheart.user.domain.UserRole;
@@ -9,15 +11,20 @@ import org.clubs.blueheart.user.domain.UserRole;
 @Builder
 public class GroupUserInfoResponseDto {
 
-    private Long id;
+    @NotBlank(message = "UserId must not be blank")
+    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
+    private Long userId;
 
     @NotBlank(message = "studentNumber must not be blank")
+    @Pattern(regexp = "^[0-9]+$")
     private String studentNumber;
 
     @NotBlank(message = "Username must not be blank")
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
     private String username;
 
     @NotBlank(message = "role must not be blank")
+    @Pattern(regexp = "^[A-Z]+$")
     private UserRole role;
 
 }

--- a/src/main/java/org/clubs/blueheart/group/dto/response/GroupUserInfoResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/group/dto/response/GroupUserInfoResponseDto.java
@@ -6,26 +6,34 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 import org.clubs.blueheart.user.domain.UserRole;
 
 @Data
 @Builder
 public class GroupUserInfoResponseDto {
 
-    @NotNull(message = "UserId must not be null")
-    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
+    @NotNull(message = "User ID must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "User ID must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long userId;
 
-    @NotBlank(message = "studentNumber must not be blank")
-    @Pattern(regexp = "^[0-9]+$")
+    @NotBlank(message = "Student number must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[0-9]+$",
+            message = "Student number must only contain numbers",
+            groups = ValidationGroups.PatternGroup.class)
     private String studentNumber;
 
-    @NotBlank(message = "Username must not be blank")
-    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
+    @NotBlank(message = "Username must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$",
+            message = "Username can only contain letters",
+            groups = ValidationGroups.PatternGroup.class)
     private String username;
 
-    @NotBlank(message = "role must not be blank")
-    @Pattern(regexp = "^[A-Z]+$")
+    @NotNull(message = "Role must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
     private UserRole role;
-
 }

--- a/src/main/java/org/clubs/blueheart/group/dto/response/GroupUserInfoResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/group/dto/response/GroupUserInfoResponseDto.java
@@ -2,6 +2,7 @@ package org.clubs.blueheart.group.dto.response;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
@@ -11,7 +12,7 @@ import org.clubs.blueheart.user.domain.UserRole;
 @Builder
 public class GroupUserInfoResponseDto {
 
-    @NotBlank(message = "UserId must not be blank")
+    @NotNull(message = "UserId must not be blank")
     @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 

--- a/src/main/java/org/clubs/blueheart/group/dto/response/GroupUserInfoResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/group/dto/response/GroupUserInfoResponseDto.java
@@ -12,7 +12,7 @@ import org.clubs.blueheart.user.domain.UserRole;
 @Builder
 public class GroupUserInfoResponseDto {
 
-    @NotNull(message = "UserId must not be blank")
+    @NotNull(message = "UserId must not be null")
     @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 

--- a/src/main/java/org/clubs/blueheart/group/repository/GroupRepository.java
+++ b/src/main/java/org/clubs/blueheart/group/repository/GroupRepository.java
@@ -15,5 +15,5 @@ public interface GroupRepository {
 
     void removeGroupUserById(GroupUserRequestDto groupUserRequestDto);
 
-    List<GroupUserInfoResponseDto> getMyGroupInfoById(Long id);
+    List<GroupUserInfoResponseDto> getMyGroupInfoByUserId(Long id);
 }

--- a/src/main/java/org/clubs/blueheart/group/repository/GroupRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/group/repository/GroupRepositoryImpl.java
@@ -32,7 +32,7 @@ public class GroupRepositoryImpl implements GroupRepository {
     @Override
     public void createGroup(GroupInfoRequestDto groupInfoRequestDto) {
         if (groupInfoRequestDto == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED);
         }
 
         boolean groupExists = groupUserDao.existsByUserId(groupInfoRequestDto.getUserId());
@@ -60,7 +60,7 @@ public class GroupRepositoryImpl implements GroupRepository {
     @Override
     public void deleteGroup(GroupInfoRequestDto groupInfoRequestDto) {
         if (groupInfoRequestDto == null || groupInfoRequestDto.getUserId() == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.AUTH_INVALID_PARAMS);
         }
 
         GroupUser groupUser = groupUserDao.findOneByUserIdAndDeletedAtIsNull(groupInfoRequestDto.getUserId())
@@ -87,7 +87,7 @@ public class GroupRepositoryImpl implements GroupRepository {
     @Override
     public void addGroupUserById(GroupUserRequestDto groupUserRequestDto) {
         if (groupUserRequestDto == null || groupUserRequestDto.getUserId() == null || groupUserRequestDto.getGroupId() == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.AUTH_INVALID_PARAMS);
         }
 
         boolean groupExists = groupUserDao.existsByUserId(groupUserRequestDto.getUserId());
@@ -112,7 +112,7 @@ public class GroupRepositoryImpl implements GroupRepository {
     @Override
     public void removeGroupUserById(GroupUserRequestDto groupUserRequestDto) {
         if (groupUserRequestDto == null || groupUserRequestDto.getUserId() == null || groupUserRequestDto.getGroupId() == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.AUTH_INVALID_PARAMS);
         }
 
         GroupUser groupUser = groupUserDao.findByGroupIdAndUserIdAndDeletedAtIsNull(
@@ -130,7 +130,7 @@ public class GroupRepositoryImpl implements GroupRepository {
     @Override
     public List<GroupUserInfoResponseDto> getMyGroupInfoById(Long userId) {
         if (userId == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.AUTH_INVALID_PARAMS);
         }
 
         GroupUser existGroupUserInfo = groupUserDao.findOneByUserIdAndDeletedAtIsNull(userId)

--- a/src/main/java/org/clubs/blueheart/group/repository/GroupRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/group/repository/GroupRepositoryImpl.java
@@ -41,7 +41,7 @@ public class GroupRepositoryImpl implements GroupRepository {
         }
 
         Group group = Group.builder()
-                .name(groupInfoRequestDto.getName())
+                .name(groupInfoRequestDto.getUsername())
                 .build();
 
         groupDao.save(group);
@@ -128,7 +128,7 @@ public class GroupRepositoryImpl implements GroupRepository {
     }
 
     @Override
-    public List<GroupUserInfoResponseDto> getMyGroupInfoById(Long userId) {
+    public List<GroupUserInfoResponseDto> getMyGroupInfoByUserId(Long userId) {
         if (userId == null) {
             throw new RepositoryException(ExceptionStatus.AUTH_INVALID_PARAMS);
         }
@@ -146,7 +146,7 @@ public class GroupRepositoryImpl implements GroupRepository {
                 .map(groupUser -> {
                     User user = groupUser.getUser();
                     return GroupUserInfoResponseDto.builder()
-                            .id(user.getId())
+                            .userId(user.getId())
                             .studentNumber(user.getStudentNumber())
                             .username(user.getUsername())
                             .role(user.getRole())

--- a/src/main/java/org/clubs/blueheart/notification/api/NotificationApi.java
+++ b/src/main/java/org/clubs/blueheart/notification/api/NotificationApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.clubs.blueheart.config.ValidationSequenceConfig;
 import org.clubs.blueheart.config.jwt.JwtUserDetails;
 import org.clubs.blueheart.notification.application.NotificationService;
 import org.clubs.blueheart.notification.dto.request.NotificationRequestDto;
@@ -14,6 +15,7 @@ import org.clubs.blueheart.response.GlobalResponseHandler;
 import org.clubs.blueheart.response.ResponseStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -49,7 +51,7 @@ public class NotificationApi {
             )
     })
     @PostMapping("/activity")
-    public ResponseEntity<GlobalResponseHandler<Void>> notificationActivity(@RequestBody @Valid NotificationRequestDto notificationRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> notificationActivity(@RequestBody @Validated(ValidationSequenceConfig.class) NotificationRequestDto notificationRequestDto) {
         notificationService.notificationActivity(notificationRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.NOTIFICATION_CREATED);
     }
@@ -75,7 +77,7 @@ public class NotificationApi {
             )
     })
     @PostMapping("/group")
-    public ResponseEntity<GlobalResponseHandler<Void>> notificationGroup(@RequestBody @Valid NotificationRequestDto notificationRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> notificationGroup(@RequestBody @Validated(ValidationSequenceConfig.class) NotificationRequestDto notificationRequestDto) {
         notificationService.notificationGroup(notificationRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.NOTIFICATION_CREATED);
     }

--- a/src/main/java/org/clubs/blueheart/notification/api/NotificationApi.java
+++ b/src/main/java/org/clubs/blueheart/notification/api/NotificationApi.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Valid;
 import org.clubs.blueheart.config.ValidationSequenceConfig;
 import org.clubs.blueheart.config.jwt.JwtUserDetails;
 import org.clubs.blueheart.notification.application.NotificationService;

--- a/src/main/java/org/clubs/blueheart/notification/dto/request/NotificationRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/notification/dto/request/NotificationRequestDto.java
@@ -3,21 +3,30 @@ package org.clubs.blueheart.notification.dto.request;
 import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 
 @Data
 @Builder
 public class NotificationRequestDto {
 
-    @NotNull(message = "SenderID must not be null")
-    @Min(value = 1, message = "송신자ID는 1이상이어야합니다.")
+    @NotNull(message = "Sender ID must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "Sender ID must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long senderId;
 
-    @NotNull(message = "ReceiverID must not be null")
-    @Min(value = 1, message = "수신자ID는 1이상이어야합니다.")
+    @NotNull(message = "Receiver ID must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "Receiver ID must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long receiverId;
 
-    @NotBlank(message = "Content must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
-    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
+    @NotBlank(message = "Content must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Content can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
+    @Size(min = 1, max = 255, message = "Content cannot exceed 255 characters",
+            groups = ValidationGroups.SizeGroup.class)
     private String content;
 }

--- a/src/main/java/org/clubs/blueheart/notification/dto/request/NotificationRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/notification/dto/request/NotificationRequestDto.java
@@ -1,5 +1,6 @@
 package org.clubs.blueheart.notification.dto.request;
 
+import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,9 +8,16 @@ import lombok.Data;
 @Builder
 public class NotificationRequestDto {
 
+    @NotNull(message = "SenderID must not be blank")
+    @Min(value = 1, message = "송신자ID는 1이상이어야합니다.")
     private Long senderId;
 
+    @NotNull(message = "ReceiverID must not be blank")
+    @Min(value = 1, message = "수신자ID는 1이상이어야합니다.")
     private Long receiverId;
 
+    @NotBlank(message = "Content must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
+    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
     private String content;
 }

--- a/src/main/java/org/clubs/blueheart/notification/dto/request/NotificationRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/notification/dto/request/NotificationRequestDto.java
@@ -8,11 +8,11 @@ import lombok.Data;
 @Builder
 public class NotificationRequestDto {
 
-    @NotNull(message = "SenderID must not be blank")
+    @NotNull(message = "SenderID must not be null")
     @Min(value = 1, message = "송신자ID는 1이상이어야합니다.")
     private Long senderId;
 
-    @NotNull(message = "ReceiverID must not be blank")
+    @NotNull(message = "ReceiverID must not be null")
     @Min(value = 1, message = "수신자ID는 1이상이어야합니다.")
     private Long receiverId;
 

--- a/src/main/java/org/clubs/blueheart/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/notification/dto/response/NotificationResponseDto.java
@@ -3,21 +3,31 @@ package org.clubs.blueheart.notification.dto.response;
 import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 
 import java.time.LocalDateTime;
 
 @Data
 @Builder
 public class NotificationResponseDto {
-    @NotBlank(message = "Content must not be blank")
-    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
-    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
+
+    @NotBlank(message = "Content must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$",
+            message = "Content can only contain letters, numbers, and symbols",
+            groups = ValidationGroups.PatternGroup.class)
+    @Size(min = 1, max = 255, message = "Content cannot exceed 255 characters",
+            groups = ValidationGroups.SizeGroup.class)
     private String content;
 
-    @NotBlank(message = "SenderUsername must not be blank")
-    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
+    @NotBlank(message = "Sender username must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$",
+            message = "Sender username can only contain letters",
+            groups = ValidationGroups.PatternGroup.class)
     private String senderUsername;
 
-    @NotNull(message = "expiredAt must not be blank")
+    @NotNull(message = "Creation timestamp must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
     private LocalDateTime createdAt;
 }

--- a/src/main/java/org/clubs/blueheart/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/notification/dto/response/NotificationResponseDto.java
@@ -1,5 +1,9 @@
 package org.clubs.blueheart.notification.dto.response;
 
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Data;
 
@@ -8,9 +12,15 @@ import java.time.LocalDateTime;
 @Data
 @Builder
 public class NotificationResponseDto {
+    @NotBlank(message = "Content must not be blank")
+    @Pattern(regexp = "^[a-zA-Z0-9ㄱ-ㅎ가-힣ㅏ-ㅣ\\uAC00-\\uD7A3\\u0020-\\u007E]*$", message="한글, 영어, 기호, 유니코드만 사용할 수 있습니다")
+    @Size(min = 1, max = 255, message = "내용은 255자 이하입니다")
     private String content;
 
+    @NotBlank(message = "SenderUsername must not be blank")
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
     private String senderUsername;
 
+    @NotBlank(message = "expiredAt must not be blank")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/org/clubs/blueheart/notification/dto/response/NotificationResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/notification/dto/response/NotificationResponseDto.java
@@ -1,9 +1,6 @@
 package org.clubs.blueheart.notification.dto.response;
 
-import jakarta.validation.constraints.Future;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Data;
 
@@ -21,6 +18,6 @@ public class NotificationResponseDto {
     @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
     private String senderUsername;
 
-    @NotBlank(message = "expiredAt must not be blank")
+    @NotNull(message = "expiredAt must not be blank")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/org/clubs/blueheart/notification/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/notification/repository/NotificationRepositoryImpl.java
@@ -36,7 +36,7 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     @Override
     public void createActivityNotification(NotificationRequestDto notificationRequestDto) {
         if (notificationRequestDto == null || notificationRequestDto.getSenderId() == null || notificationRequestDto.getReceiverId() == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.NOTIFICATION_INVALID_PARAMS);
         }
 
         // Fetch sender User entity
@@ -71,7 +71,7 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     @Override
     public void createGroupNotification(NotificationRequestDto notificationRequestDto) {
         if (notificationRequestDto == null || notificationRequestDto.getSenderId() == null || notificationRequestDto.getReceiverId() == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.NOTIFICATION_INVALID_PARAMS);
         }
 
         // Fetch sender User entity
@@ -106,7 +106,7 @@ public class NotificationRepositoryImpl implements NotificationRepository {
     @Override
     public List<NotificationResponseDto> findAllNotificationMe(Long receiverId) {
         if (receiverId == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.NOTIFICATION_INVALID_PARAMS);
         }
 
         List<Notification> notifications = notificationDao.findAllByReceiverId_IdAndDeletedAtIsNull(receiverId);

--- a/src/main/java/org/clubs/blueheart/response/ResponseStatus.java
+++ b/src/main/java/org/clubs/blueheart/response/ResponseStatus.java
@@ -27,6 +27,13 @@ public enum ResponseStatus {
     ACTIVITY_HISTORY_UNSUBSCRIBED(HttpStatus.OK, "액티비티를 성공적으로 구독해지했습니다"),
 
     // AUTH RESPONSE CODE
+    AUTH_USER_CREATED(HttpStatus.CREATED, "유저가 생성되었습니다"),
+    AUTH_LOGGED_IN(HttpStatus.OK, "성공적으로 로그인되었습니다"),
+    AUTH_LOGGED_OUT(HttpStatus.OK, "성공적으로 로그아웃되었습니다"),
+
+    AUTH_INVITE_LINK_CREATED(HttpStatus.CREATED, "초대 링크가 성공적으로 생성되었습니다"),
+    AUTH_VERIFIED(HttpStatus.OK, "성공적으로 인증되었습니다"),
+
 
     // GROUP RESPONSE CODE
     GROUP_CREATED(HttpStatus.CREATED, "그룹이 성공적으로 생성되었습니다"),

--- a/src/main/java/org/clubs/blueheart/user/api/UserApi.java
+++ b/src/main/java/org/clubs/blueheart/user/api/UserApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.clubs.blueheart.config.ValidationSequenceConfig;
 import org.clubs.blueheart.exception.CustomExceptionStatus;
 import org.clubs.blueheart.response.GlobalResponseHandler;
 import org.clubs.blueheart.response.ResponseStatus;
@@ -15,6 +16,7 @@ import org.clubs.blueheart.user.dto.request.UserInfoRequestDto;
 import org.clubs.blueheart.user.dto.request.UserUpdateRequestDto;
 import org.clubs.blueheart.user.dto.response.UserInfoResponseDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -73,7 +75,7 @@ public class UserApi {
             )
     })
     @PostMapping("/create")
-    public ResponseEntity<GlobalResponseHandler<Void>> createUser(@RequestBody @Valid UserInfoRequestDto userInfoRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> createUser(@RequestBody @Validated(ValidationSequenceConfig.class) UserInfoRequestDto userInfoRequestDto) {
         userService.createUser(userInfoRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.USER_CREATED);
     }
@@ -139,7 +141,7 @@ public class UserApi {
             )
     })
     @PutMapping("/update")
-    public ResponseEntity<GlobalResponseHandler<Void>> updateUser(@RequestBody @Valid UserUpdateRequestDto userUpdateRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> updateUser(@RequestBody @Validated(ValidationSequenceConfig.class) UserUpdateRequestDto userUpdateRequestDto) {
         userService.updateUserById(userUpdateRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.USER_UPDATED);
     }
@@ -172,7 +174,7 @@ public class UserApi {
             )
     })
     @DeleteMapping("/delete")
-    public ResponseEntity<GlobalResponseHandler<Void>> deleteUser(@RequestBody @Valid UserDeleteRequestDto userDeleteRequestDto) {
+    public ResponseEntity<GlobalResponseHandler<Void>> deleteUser(@RequestBody @Validated(ValidationSequenceConfig.class) UserDeleteRequestDto userDeleteRequestDto) {
         userService.deleteUserById(userDeleteRequestDto);
         return GlobalResponseHandler.success(ResponseStatus.USER_DELETED);
     }

--- a/src/main/java/org/clubs/blueheart/user/api/UserApi.java
+++ b/src/main/java/org/clubs/blueheart/user/api/UserApi.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import jakarta.validation.Valid;
 import org.clubs.blueheart.config.ValidationSequenceConfig;
 import org.clubs.blueheart.exception.CustomExceptionStatus;
 import org.clubs.blueheart.response.GlobalResponseHandler;

--- a/src/main/java/org/clubs/blueheart/user/dao/UserRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/user/dao/UserRepositoryImpl.java
@@ -96,9 +96,9 @@ public class UserRepositoryImpl implements UserRepository {
 
         // Update fields using updateFields
         User updatedUser = existingUser.updatedUserFields(
-                userUpdateRequestDto.getUsername().orElse(null),
-                userUpdateRequestDto.getStudentNumber().orElse(null),
-                userUpdateRequestDto.getRole().orElse(null)
+                userUpdateRequestDto.getUsername(),
+                userUpdateRequestDto.getStudentNumber(),
+                userUpdateRequestDto.getRole()
         );
 
         // Save the updated user

--- a/src/main/java/org/clubs/blueheart/user/dao/UserRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/user/dao/UserRepositoryImpl.java
@@ -27,7 +27,7 @@ public class UserRepositoryImpl implements UserRepository {
     public void createUser(UserInfoRequestDto userInfoRequestDto) {
         // Validate input data
         if (userInfoRequestDto == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.USER_INVALID_PARAMS);
         }
 
         // Check if the user already exists using a LIMIT 1 query
@@ -50,7 +50,7 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public List<UserInfoResponseDto> findUserByStudentNumber(String studentNumber) {
         if (studentNumber == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.USER_INVALID_PARAMS);
         }
 
         // Fetch user list and map to DTOs
@@ -68,7 +68,7 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public List<UserInfoResponseDto> findUserByUsername(String username) {
         if (username == null || username.trim().isEmpty()) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.USER_INVALID_PARAMS);
         }
 
         // Fetch user list and map to DTOs
@@ -87,7 +87,7 @@ public class UserRepositoryImpl implements UserRepository {
     public void updateUserById(UserUpdateRequestDto userUpdateRequestDto) {
         // Validate input data
         if (userUpdateRequestDto == null || userUpdateRequestDto.getId() == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.USER_INVALID_PARAMS);
         }
 
         // Fetch the user
@@ -109,7 +109,7 @@ public class UserRepositoryImpl implements UserRepository {
     public void deleteUserById(UserDeleteRequestDto userDeleteRequestDto) {
         // Validate input data
         if (userDeleteRequestDto == null || userDeleteRequestDto.getId() == null) {
-            throw new RepositoryException(ExceptionStatus.GENERAL_INVALID_ARGUMENT);
+            throw new RepositoryException(ExceptionStatus.USER_INVALID_PARAMS);
         }
 
         // Fetch the user

--- a/src/main/java/org/clubs/blueheart/user/dao/UserRepositoryImpl.java
+++ b/src/main/java/org/clubs/blueheart/user/dao/UserRepositoryImpl.java
@@ -86,12 +86,12 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public void updateUserById(UserUpdateRequestDto userUpdateRequestDto) {
         // Validate input data
-        if (userUpdateRequestDto == null || userUpdateRequestDto.getId() == null) {
+        if (userUpdateRequestDto == null || userUpdateRequestDto.getUserId() == null) {
             throw new RepositoryException(ExceptionStatus.USER_INVALID_PARAMS);
         }
 
         // Fetch the user
-        User existingUser = userDao.findUserByIdAndDeletedAtIsNull(userUpdateRequestDto.getId())
+        User existingUser = userDao.findUserByIdAndDeletedAtIsNull(userUpdateRequestDto.getUserId())
                 .orElseThrow(() -> new RepositoryException(ExceptionStatus.USER_NOT_FOUND_USER));
 
         // Update fields using updateFields
@@ -108,12 +108,12 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public void deleteUserById(UserDeleteRequestDto userDeleteRequestDto) {
         // Validate input data
-        if (userDeleteRequestDto == null || userDeleteRequestDto.getId() == null) {
+        if (userDeleteRequestDto == null || userDeleteRequestDto.getUserId() == null) {
             throw new RepositoryException(ExceptionStatus.USER_INVALID_PARAMS);
         }
 
         // Fetch the user
-        User existingUser = userDao.findUserByIdAndDeletedAtIsNull(userDeleteRequestDto.getId())
+        User existingUser = userDao.findUserByIdAndDeletedAtIsNull(userDeleteRequestDto.getUserId())
                 .orElseThrow(() -> new RepositoryException(ExceptionStatus.USER_NOT_FOUND_USER));
 
         // Update the deletedAt field to mark as deleted

--- a/src/main/java/org/clubs/blueheart/user/dto/request/UserDeleteRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/user/dto/request/UserDeleteRequestDto.java
@@ -1,15 +1,17 @@
 package org.clubs.blueheart.user.dto.request;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 
 @Data
 @Builder
 public class UserDeleteRequestDto {
-    @NotNull(message = "UserID must not be blank")
-    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
+    @NotNull(message = "User ID must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "User ID must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long userId;
 }

--- a/src/main/java/org/clubs/blueheart/user/dto/request/UserDeleteRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/user/dto/request/UserDeleteRequestDto.java
@@ -2,13 +2,14 @@ package org.clubs.blueheart.user.dto.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
 public class UserDeleteRequestDto {
-    @NotBlank(message = "UserID must not be blank")
+    @NotNull(message = "UserID must not be blank")
     @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 }

--- a/src/main/java/org/clubs/blueheart/user/dto/request/UserDeleteRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/user/dto/request/UserDeleteRequestDto.java
@@ -1,11 +1,14 @@
 package org.clubs.blueheart.user.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 @Builder
 public class UserDeleteRequestDto {
-
-    private Long id;
+    @NotBlank(message = "UserID must not be blank")
+    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
+    private Long userId;
 }

--- a/src/main/java/org/clubs/blueheart/user/dto/request/UserInfoRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/user/dto/request/UserInfoRequestDto.java
@@ -11,11 +11,11 @@ import org.clubs.blueheart.user.domain.UserRole;
 @Builder
 public class UserInfoRequestDto {
     @NotBlank(message = "Username must not be blank")
-    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$", message = "Username must only contain letters")
     private String username;
 
     @NotBlank(message = "studentNumber must not be blank")
-    @Pattern(regexp = "^[0-9]+$")
+    @Pattern(regexp = "^[0-9]+$", message = "studentNumber must contain only numbers")
     private String studentNumber;
 
     @NotNull(message = "role must not be blank")

--- a/src/main/java/org/clubs/blueheart/user/dto/request/UserInfoRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/user/dto/request/UserInfoRequestDto.java
@@ -2,6 +2,7 @@ package org.clubs.blueheart.user.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
 import org.clubs.blueheart.user.domain.UserRole;
@@ -10,11 +11,14 @@ import org.clubs.blueheart.user.domain.UserRole;
 @Builder
 public class UserInfoRequestDto {
     @NotBlank(message = "Username must not be blank")
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
     private String username;
 
-    @NotNull(message = "Student number must not be null")
+    @NotBlank(message = "studentNumber must not be blank")
+    @Pattern(regexp = "^[0-9]+$")
     private String studentNumber;
 
-    @NotNull(message = "User role must not be null")
+    @NotBlank(message = "role must not be blank")
+    @Pattern(regexp = "^[A-Z]+$")
     private UserRole role;
 }

--- a/src/main/java/org/clubs/blueheart/user/dto/request/UserInfoRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/user/dto/request/UserInfoRequestDto.java
@@ -18,7 +18,6 @@ public class UserInfoRequestDto {
     @Pattern(regexp = "^[0-9]+$")
     private String studentNumber;
 
-    @NotBlank(message = "role must not be blank")
-    @Pattern(regexp = "^[A-Z]+$")
+    @NotNull(message = "role must not be blank")
     private UserRole role;
 }

--- a/src/main/java/org/clubs/blueheart/user/dto/request/UserInfoRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/user/dto/request/UserInfoRequestDto.java
@@ -5,19 +5,28 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 import org.clubs.blueheart.user.domain.UserRole;
 
 @Data
 @Builder
 public class UserInfoRequestDto {
-    @NotBlank(message = "Username must not be blank")
-    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$", message = "Username must only contain letters")
+
+    @NotBlank(message = "Username must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$",
+            message = "Username must only contain letters",
+            groups = ValidationGroups.PatternGroup.class)
     private String username;
 
-    @NotBlank(message = "studentNumber must not be blank")
-    @Pattern(regexp = "^[0-9]+$", message = "studentNumber must contain only numbers")
+    @NotBlank(message = "Student number must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
+    @Pattern(regexp = "^[0-9]+$",
+            message = "Student number must contain only numbers",
+            groups = ValidationGroups.PatternGroup.class)
     private String studentNumber;
 
-    @NotNull(message = "role must not be blank")
+    @NotNull(message = "User role must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
     private UserRole role;
 }

--- a/src/main/java/org/clubs/blueheart/user/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/user/dto/request/UserUpdateRequestDto.java
@@ -2,6 +2,7 @@ package org.clubs.blueheart.user.dto.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
@@ -12,16 +13,15 @@ import java.util.Optional;
 @Data
 @Builder
 public class UserUpdateRequestDto {
-    @NotBlank(message = "UserId must not be blank")
+    @NotNull(message = "UserId must not be blank")
     @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
     private Long userId;
 
     @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
-    private Optional<String> username = Optional.empty();
+    private String username;
 
     @Pattern(regexp = "^[0-9]+$")
-    private Optional<String> studentNumber = Optional.empty();
+    private String studentNumber;
 
-    @Pattern(regexp = "^[A-Z]+$")
-    private Optional<UserRole> role = Optional.empty();
+    private UserRole role;
 }

--- a/src/main/java/org/clubs/blueheart/user/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/user/dto/request/UserUpdateRequestDto.java
@@ -1,27 +1,34 @@
 package org.clubs.blueheart.user.dto.request;
 
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
+import org.clubs.blueheart.config.ValidationGroups;
 import org.clubs.blueheart.user.domain.UserRole;
-
-import java.util.Optional;
 
 @Data
 @Builder
 public class UserUpdateRequestDto {
-    @NotNull(message = "UserId must not be blank")
-    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
+
+    @NotNull(message = "User ID must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
+    @Min(value = 1, message = "User ID must be at least 1",
+            groups = ValidationGroups.SizeGroup.class)
     private Long userId;
 
-    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$",
+            message = "Username must only contain letters",
+            groups = ValidationGroups.PatternGroup.class)
     private String username;
 
-    @Pattern(regexp = "^[0-9]+$")
+    @Pattern(regexp = "^[0-9]+$",
+            message = "Student number must contain only numbers",
+            groups = ValidationGroups.PatternGroup.class)
     private String studentNumber;
 
+    @NotNull(message = "Role must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
     private UserRole role;
 }

--- a/src/main/java/org/clubs/blueheart/user/dto/request/UserUpdateRequestDto.java
+++ b/src/main/java/org/clubs/blueheart/user/dto/request/UserUpdateRequestDto.java
@@ -1,5 +1,8 @@
 package org.clubs.blueheart.user.dto.request;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
 import org.clubs.blueheart.user.domain.UserRole;
@@ -9,11 +12,16 @@ import java.util.Optional;
 @Data
 @Builder
 public class UserUpdateRequestDto {
-    private Long id;
+    @NotBlank(message = "UserId must not be blank")
+    @Min(value = 1, message = "사용자ID는 1이상이어야합니다.")
+    private Long userId;
 
+    @Pattern(regexp = "^[a-zA-Zㄱ-ㅎ가-힣ㅏ-ㅣ]+$")
     private Optional<String> username = Optional.empty();
 
+    @Pattern(regexp = "^[0-9]+$")
     private Optional<String> studentNumber = Optional.empty();
 
+    @Pattern(regexp = "^[A-Z]+$")
     private Optional<UserRole> role = Optional.empty();
 }

--- a/src/main/java/org/clubs/blueheart/user/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/org/clubs/blueheart/user/dto/response/UserInfoResponseDto.java
@@ -5,16 +5,21 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Data;
 import org.clubs.blueheart.user.domain.UserRole;
+import org.clubs.blueheart.config.ValidationGroups;
 
 @Data
 @Builder
 public class UserInfoResponseDto {
-    @NotBlank(message = "Username must not be blank")
+
+    @NotBlank(message = "Username must not be blank",
+            groups = ValidationGroups.NotBlankGroup.class)
     private String username;
 
-    @NotNull(message = "Student number must not be null")
+    @NotNull(message = "Student number must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
     private String studentNumber;
 
-    @NotNull(message = "User role must not be null")
+    @NotNull(message = "User role must not be null",
+            groups = ValidationGroups.NotNullGroup.class)
     private UserRole role;
 }

--- a/src/test/java/org/clubs/blueheart/BlueheartBeApplicationTests.java
+++ b/src/test/java/org/clubs/blueheart/BlueheartBeApplicationTests.java
@@ -1,4 +1,4 @@
-package org.blueheart.blueheart;
+package org.clubs.blueheart;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/src/test/java/org/clubs/blueheart/activity/api/ActivityApiTest.java
+++ b/src/test/java/org/clubs/blueheart/activity/api/ActivityApiTest.java
@@ -17,10 +17,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -38,7 +39,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
-@org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+@AutoConfigureMockMvc
 class ActivityApiTest {
 
     @Autowired
@@ -50,7 +51,7 @@ class ActivityApiTest {
     @Autowired
     private JwtGenerator jwtGenerator;  // 실제 Bean 주입
 
-    @MockBean
+    @MockitoBean
     private ActivityService activityService;
 
     private String token;
@@ -179,12 +180,10 @@ class ActivityApiTest {
                 .content(requestBody));
 
         // Then
-        // 예상 응답 메시지: "잘못된 쿠키로 접근했습니다!"
         MvcResult mvcResult = resultActions
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getStatusCode()))
                 .andExpect(jsonPath("$.message").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getMessage()))
-                .andExpect(jsonPath("$.error").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getError()))
                 .andDo(MockMvcResultHandlers.print())
                 .andReturn();
 

--- a/src/test/java/org/clubs/blueheart/activity/api/ActivityApiTest.java
+++ b/src/test/java/org/clubs/blueheart/activity/api/ActivityApiTest.java
@@ -1,0 +1,319 @@
+package org.clubs.blueheart.activity.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.clubs.blueheart.activity.application.ActivityService;
+import org.clubs.blueheart.activity.domain.ActivityStatus;
+import org.clubs.blueheart.activity.dto.request.ActivityCreateRequestDto;
+import org.clubs.blueheart.activity.dto.request.ActivityDeleteRequestDto;
+import org.clubs.blueheart.activity.dto.request.ActivityUpdateRequestDto;
+import org.clubs.blueheart.activity.dto.response.ActivityDetailResponseDto;
+import org.clubs.blueheart.activity.dto.response.ActivitySearchResponseDto;
+import org.clubs.blueheart.config.jwt.JwtGenerator;
+import org.clubs.blueheart.config.jwt.JwtProvider;
+import org.clubs.blueheart.response.ResponseStatus;
+import org.clubs.blueheart.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// (B안) 전체 컨텍스트 로딩 & 보안 필터 적용
+@SpringBootTest
+@org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+class ActivityApiTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtGenerator jwtGenerator;  // 실제 Bean 주입
+
+    @MockBean
+    private ActivityService activityService;
+
+    // JwtCookieFilter를 MockBean으로 등록하지 말고, 실제 필터가 동작하도록 유지
+    // @MockBean
+    // private JwtCookieFilter jwtCookieFilter;
+
+    private String token;
+
+    @BeforeEach
+    void setup() {
+        // 테스트 시작 전에 유효한 JWT 토큰 생성
+        token = createLoginJwt(1L, "201234567", "홍길동", UserRole.USER);
+    }
+
+    /**
+     * JwtProvider를 사용하여 테스트용 JWT 토큰을 생성하는 유틸 메서드
+     */
+    public String createLoginJwt(Long userId, String studentNumber, String username, UserRole role) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("userId", userId);
+        payload.put("studentNumber", studentNumber);
+        payload.put("username", username);
+        payload.put("role", role);
+
+        // 예: 최종 JWT는 1일 유효
+        long finalExpire = 24L * 60 * 60 * 1000;
+
+        return jwtGenerator.createToken(payload, finalExpire);
+    }
+
+    @Test
+    @DisplayName("빌더로 생성한 ActivityCreateRequestDto로 액티비티 생성 테스트 (인증 사용)")
+    void createActivityWithBuilder_ShouldReturn201() throws Exception {
+        // Given
+        // mock service가 있다고 치고, 실제 db 저장은 생략
+        ActivityCreateRequestDto requestDto = ActivityCreateRequestDto.builder()
+                .creatorId(1L)
+                .title("Sample Activity")
+                .maxNumber(10)
+                .description("Test description")
+                .place("Seoul")
+                .placeUrl("http://example.com")
+                .expiredAt(LocalDateTime.now().plusDays(1))
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/activity/create")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_CREATED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_CREATED.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("특정 ID로 액티비티 세부 정보 조회 (인증 사용)")
+    void findOneActivityDetailById_ShouldReturn200() throws Exception {
+        // Given
+        // mock service
+        ActivityDetailResponseDto responseDto = ActivityDetailResponseDto.builder()
+                .activityId(1L)
+                .title("Sample Activity")
+                .status(ActivityStatus.PROGRESSING)
+                .isSubscribed(true)
+                .place("Seoul")
+                .currentNumber(3)
+                .maxNumber(10)
+                .expiredAt(LocalDateTime.now().plusDays(1))
+                .description("This is a sample activity description.")
+                .placeUrl("http://example.com")
+                .build();
+
+        Mockito.when(activityService.findOneActivityDetailById(1L))
+                .thenReturn(responseDto);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/activity/detail/1")
+                .header("Authorization", "Bearer " + token));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value("Sample Activity"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    // 그 외 updateActivity, findActivityByStatus, deleteActivity 등도
+    // 동일하게 "Authorization" 헤더에 토큰을 넣어서 호출하면 됩니다.
+
+    @Test
+    @DisplayName("액티비티를 삭제합니다 (인증 사용)")
+    void deleteActivity_ShouldReturn200() throws Exception {
+        // Given
+        ActivityDeleteRequestDto requestDto = ActivityDeleteRequestDto.builder()
+                .activityId(1L)
+                .build();
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(delete("/api/v1/activity/delete")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_DELETED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_DELETED.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("빌더로 생성한 ActivityUpdateRequestDto로 액티비티 업데이트 테스트 (인증 사용)")
+    void updateActivity_ShouldReturn200() throws Exception {
+        // Given
+        ActivityUpdateRequestDto updateRequestDto = ActivityUpdateRequestDto.builder()
+                .activityId(1L)
+                .title("Updated Activity Title")
+                .status(ActivityStatus.DONE)
+                .maxNumber(15)
+                .description("Updated description")
+                .place("Busan")
+                .placeUrl("http://updated-example.com")
+                .expiredAt(LocalDateTime.now().plusDays(2))
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(updateRequestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(activityService).updateActivity(Mockito.any(ActivityUpdateRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(put("/api/v1/activity/update")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_UPDATED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_UPDATED.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("특정 상태의 액티비티를 조회합니다 (인증 사용)")
+    void findActivityByStatus_ShouldReturn200() throws Exception {
+        // Given
+        ActivityStatus status = ActivityStatus.PROGRESSING;
+
+        List<ActivitySearchResponseDto> mockActivities = List.of(
+                ActivitySearchResponseDto.builder()
+                        .activityId(1L)
+                        .title("Activity 1")
+                        .status(ActivityStatus.PROGRESSING)
+                        .isSubscribed(true)
+                        .place("Seoul")
+                        .currentNumber(5)
+                        .maxNumber(10)
+                        .expiredAt(LocalDateTime.now().plusDays(1))
+                        .build(),
+                ActivitySearchResponseDto.builder()
+                        .activityId(2L)
+                        .title("Activity 2")
+                        .status(ActivityStatus.PROGRESSING)
+                        .isSubscribed(false)
+                        .place("Busan")
+                        .currentNumber(3)
+                        .maxNumber(10)
+                        .expiredAt(LocalDateTime.now().plusDays(3))
+                        .build()
+        );
+
+        Mockito.when(activityService.findActivityByStatus(status)).thenReturn(mockActivities);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/activity/" + status.name())
+                .header("Authorization", "Bearer " + token));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_SEARCHED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_SEARCHED.getMessage()))
+                .andExpect(jsonPath("$.data.length()").value(mockActivities.size()))
+                .andExpect(jsonPath("$.data[0].activityId").value(1L))
+                .andExpect(jsonPath("$.data[0].title").value("Activity 1"))
+                .andExpect(jsonPath("$.data[1].activityId").value(2L))
+                .andExpect(jsonPath("$.data[1].title").value("Activity 2"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("모든 액티비티를 조회합니다 (인증 사용)")
+    void findAllActivity_ShouldReturn200() throws Exception {
+        // Given
+        List<ActivitySearchResponseDto> mockActivities = List.of(
+                ActivitySearchResponseDto.builder()
+                        .activityId(1L)
+                        .title("Activity 1")
+                        .status(ActivityStatus.PROGRESSING)
+                        .isSubscribed(true)
+                        .place("Seoul")
+                        .currentNumber(5)
+                        .maxNumber(10)
+                        .expiredAt(LocalDateTime.now().plusDays(1))
+                        .build(),
+                ActivitySearchResponseDto.builder()
+                        .activityId(2L)
+                        .title("Activity 2")
+                        .status(ActivityStatus.COMPLETED)
+                        .isSubscribed(false)
+                        .place("Busan")
+                        .currentNumber(10)
+                        .maxNumber(10)
+                        .expiredAt(LocalDateTime.now().plusDays(3))
+                        .build()
+        );
+
+        Mockito.when(activityService.findAllActivity()).thenReturn(mockActivities);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/activity/all")
+                .header("Authorization", "Bearer " + token));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_SEARCHED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_SEARCHED.getMessage()))
+                .andExpect(jsonPath("$.data.length()").value(mockActivities.size()))
+                .andExpect(jsonPath("$.data[0].activityId").value(1L))
+                .andExpect(jsonPath("$.data[0].title").value("Activity 1"))
+                .andExpect(jsonPath("$.data[1].activityId").value(2L))
+                .andExpect(jsonPath("$.data[1].title").value("Activity 2"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+}

--- a/src/test/java/org/clubs/blueheart/activity/api/ActivityApiTest.java
+++ b/src/test/java/org/clubs/blueheart/activity/api/ActivityApiTest.java
@@ -7,9 +7,9 @@ import org.clubs.blueheart.activity.dto.request.ActivityCreateRequestDto;
 import org.clubs.blueheart.activity.dto.request.ActivityDeleteRequestDto;
 import org.clubs.blueheart.activity.dto.request.ActivityUpdateRequestDto;
 import org.clubs.blueheart.activity.dto.response.ActivityDetailResponseDto;
-import org.clubs.blueheart.activity.dto.response.ActivitySearchResponseDto;
 import org.clubs.blueheart.config.jwt.JwtGenerator;
-import org.clubs.blueheart.config.jwt.JwtProvider;
+import org.clubs.blueheart.exception.ExceptionStatus;
+import org.clubs.blueheart.exception.RepositoryException;
 import org.clubs.blueheart.response.ResponseStatus;
 import org.clubs.blueheart.user.domain.UserRole;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +19,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -27,17 +28,15 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-// (B안) 전체 컨텍스트 로딩 & 보안 필터 적용
 @SpringBootTest
 @org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 class ActivityApiTest {
@@ -53,10 +52,6 @@ class ActivityApiTest {
 
     @MockBean
     private ActivityService activityService;
-
-    // JwtCookieFilter를 MockBean으로 등록하지 말고, 실제 필터가 동작하도록 유지
-    // @MockBean
-    // private JwtCookieFilter jwtCookieFilter;
 
     private String token;
 
@@ -82,11 +77,13 @@ class ActivityApiTest {
         return jwtGenerator.createToken(payload, finalExpire);
     }
 
+    /**
+     * 1. 액티비티 생성 성공 테스트
+     */
     @Test
-    @DisplayName("빌더로 생성한 ActivityCreateRequestDto로 액티비티 생성 테스트 (인증 사용)")
+    @DisplayName("빌더로 생성한 ActivityCreateRequestDto로 액티비티 생성 성공 테스트 (인증 사용)")
     void createActivityWithBuilder_ShouldReturn201() throws Exception {
         // Given
-        // mock service가 있다고 치고, 실제 db 저장은 생략
         ActivityCreateRequestDto requestDto = ActivityCreateRequestDto.builder()
                 .creatorId(1L)
                 .title("Sample Activity")
@@ -98,6 +95,9 @@ class ActivityApiTest {
                 .build();
 
         String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(activityService).createActivity(any(ActivityCreateRequestDto.class));
 
         // When
         ResultActions resultActions = mockMvc.perform(post("/api/v1/activity/create")
@@ -116,11 +116,88 @@ class ActivityApiTest {
         System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
     }
 
+    /**
+     * 1-1. 액티비티 생성 실패 테스트: 잘못된 입력 데이터 (400 Bad Request)
+     */
     @Test
-    @DisplayName("특정 ID로 액티비티 세부 정보 조회 (인증 사용)")
+    @DisplayName("액티비티 생성 실패 테스트: 잘못된 입력 데이터 (400 Bad Request)")
+    void createActivity_WithInvalidInput_ShouldReturn400() throws Exception {
+        // Given: title이 빈 문자열인 경우
+        ActivityCreateRequestDto requestDto = ActivityCreateRequestDto.builder()
+                .creatorId(1L)
+                .title("")  // 유효하지 않은 title
+                .maxNumber(10)
+                .description("Test description")
+                .place("Seoul")
+                .placeUrl("http://example.com")
+                .expiredAt(LocalDateTime.now().plusDays(1))
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/activity/create")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        // 예상 응답 메시지: "잘못된 액티비티 요청입니다: title: must not be empty"
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.GENERAL_BAD_REQUEST.getStatusCode()))
+                .andExpect(jsonPath("$.message").value("title: Title must not be blank"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 1-2. 액티비티 생성 실패 테스트: 인증 실패 (401 Unauthorized)
+     */
+    @Test
+    @DisplayName("액티비티 생성 실패 테스트: 인증 실패 (401 Unauthorized)")
+    void createActivity_WithInvalidToken_ShouldReturn401() throws Exception {
+        // Given
+        ActivityCreateRequestDto requestDto = ActivityCreateRequestDto.builder()
+                .creatorId(1L)
+                .title("Sample Activity")
+                .maxNumber(10)
+                .description("Test description")
+                .place("Seoul")
+                .placeUrl("http://example.com")
+                .expiredAt(LocalDateTime.now().plusDays(1))
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // When: 유효하지 않은 토큰 사용
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/activity/create")
+                .header("Authorization", "Bearer invalid_token")  // 유효하지 않은 토큰
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        // 예상 응답 메시지: "잘못된 쿠키로 접근했습니다!"
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getMessage()))
+                .andExpect(jsonPath("$.error").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getError()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 2. 특정 ID로 액티비티 세부 정보 조회 성공 테스트
+     */
+    @Test
+    @DisplayName("특정 ID로 액티비티 세부 정보 조회 성공 테스트 (인증 사용)")
     void findOneActivityDetailById_ShouldReturn200() throws Exception {
         // Given
-        // mock service
         ActivityDetailResponseDto responseDto = ActivityDetailResponseDto.builder()
                 .activityId(1L)
                 .title("Sample Activity")
@@ -145,43 +222,71 @@ class ActivityApiTest {
         MvcResult mvcResult = resultActions
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.title").value("Sample Activity"))
+                .andExpect(jsonPath("$.statusCode").value(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_SEARCHED.getMessage()))
                 .andDo(MockMvcResultHandlers.print())
                 .andReturn();
 
         System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
     }
 
-    // 그 외 updateActivity, findActivityByStatus, deleteActivity 등도
-    // 동일하게 "Authorization" 헤더에 토큰을 넣어서 호출하면 됩니다.
-
+    /**
+     * 2-1. 액티비티 세부 정보 조회 실패 테스트: 존재하지 않는 ID (404 Not Found)
+     */
     @Test
-    @DisplayName("액티비티를 삭제합니다 (인증 사용)")
-    void deleteActivity_ShouldReturn200() throws Exception {
-        // Given
-        ActivityDeleteRequestDto requestDto = ActivityDeleteRequestDto.builder()
-                .activityId(1L)
-                .build();
-        String requestBody = objectMapper.writeValueAsString(requestDto);
+    @DisplayName("액티비티 세부 정보 조회 실패 테스트: 존재하지 않는 ID (404 Not Found)")
+    void findOneActivityDetailById_NotFound_ShouldReturn404() throws Exception {
+        // Given: 존재하지 않는 액티비티 ID
+        Long nonExistentId = 999L;
+
+        Mockito.when(activityService.findOneActivityDetailById(nonExistentId))
+                .thenThrow(new RepositoryException(ExceptionStatus.ACTIVITY_NOT_FOUND));
 
         // When
-        ResultActions resultActions = mockMvc.perform(delete("/api/v1/activity/delete")
-                .header("Authorization", "Bearer " + token)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody));
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/activity/detail/" + nonExistentId)
+                .header("Authorization", "Bearer " + token));
 
         // Then
         MvcResult mvcResult = resultActions
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_DELETED.getStatusCode()))
-                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_DELETED.getMessage()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.ACTIVITY_NOT_FOUND.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.ACTIVITY_NOT_FOUND.getMessage()))
                 .andDo(MockMvcResultHandlers.print())
                 .andReturn();
 
         System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
     }
 
+    /**
+     * 2-2. 액티비티 세부 정보 조회 실패 테스트: 인증 실패 (401 Unauthorized)
+     */
     @Test
-    @DisplayName("빌더로 생성한 ActivityUpdateRequestDto로 액티비티 업데이트 테스트 (인증 사용)")
+    @DisplayName("액티비티 세부 정보 조회 실패 테스트: 인증 실패 (401 Unauthorized)")
+    void findOneActivityDetailById_WithInvalidToken_ShouldReturn401() throws Exception {
+        // Given: 존재하지 않는 액티비티 ID
+        Long activityId = 1L;
+
+        // When: 유효하지 않은 토큰 사용
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/activity/detail/" + activityId)
+                .header("Authorization", "Bearer invalid_token"));
+
+        // Then
+        // 예상 응답 메시지: "잘못된 쿠키로 접근했습니다!"
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 3. 액티비티 업데이트 성공 테스트
+     */
+    @Test
+    @DisplayName("빌더로 생성한 ActivityUpdateRequestDto로 액티비티 업데이트 성공 테스트 (인증 사용)")
     void updateActivity_ShouldReturn200() throws Exception {
         // Given
         ActivityUpdateRequestDto updateRequestDto = ActivityUpdateRequestDto.builder()
@@ -217,100 +322,321 @@ class ActivityApiTest {
         System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
     }
 
+    /**
+     * 3-1. 액티비티 업데이트 실패 테스트: 존재하지 않는 ID (404 Not Found)
+     */
     @Test
-    @DisplayName("특정 상태의 액티비티를 조회합니다 (인증 사용)")
-    void findActivityByStatus_ShouldReturn200() throws Exception {
-        // Given
-        ActivityStatus status = ActivityStatus.PROGRESSING;
+    @DisplayName("액티비티 업데이트 실패 테스트: 존재하지 않는 ID (404 Not Found)")
+    void updateActivity_WithNonExistentId_ShouldReturn404() throws Exception {
+        // Given: 존재하지 않는 액티비티 ID
+        ActivityUpdateRequestDto updateRequestDto = ActivityUpdateRequestDto.builder()
+                .activityId(999L)
+                .title("Updated Activity Title")
+                .status(ActivityStatus.DONE)
+                .maxNumber(15)
+                .description("Updated description")
+                .place("Busan")
+                .placeUrl("http://updated-example.com")
+                .expiredAt(LocalDateTime.now().plusDays(2))
+                .build();
 
-        List<ActivitySearchResponseDto> mockActivities = List.of(
-                ActivitySearchResponseDto.builder()
-                        .activityId(1L)
-                        .title("Activity 1")
-                        .status(ActivityStatus.PROGRESSING)
-                        .isSubscribed(true)
-                        .place("Seoul")
-                        .currentNumber(5)
-                        .maxNumber(10)
-                        .expiredAt(LocalDateTime.now().plusDays(1))
-                        .build(),
-                ActivitySearchResponseDto.builder()
-                        .activityId(2L)
-                        .title("Activity 2")
-                        .status(ActivityStatus.PROGRESSING)
-                        .isSubscribed(false)
-                        .place("Busan")
-                        .currentNumber(3)
-                        .maxNumber(10)
-                        .expiredAt(LocalDateTime.now().plusDays(3))
-                        .build()
-        );
+        String requestBody = objectMapper.writeValueAsString(updateRequestDto);
 
-        Mockito.when(activityService.findActivityByStatus(status)).thenReturn(mockActivities);
+        // Mocking the service method to throw exception
+        Mockito.doThrow(new RepositoryException(ExceptionStatus.ACTIVITY_NOT_FOUND))
+                .when(activityService).updateActivity(Mockito.any(ActivityUpdateRequestDto.class));
 
         // When
-        ResultActions resultActions = mockMvc.perform(get("/api/v1/activity/" + status.name())
-                .header("Authorization", "Bearer " + token));
+        ResultActions resultActions = mockMvc.perform(put("/api/v1/activity/update")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
 
         // Then
+        // 예상 응답 메시지: "액티비티를 찾을 수 없습니다"
         MvcResult mvcResult = resultActions
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_SEARCHED.getStatusCode()))
-                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_SEARCHED.getMessage()))
-                .andExpect(jsonPath("$.data.length()").value(mockActivities.size()))
-                .andExpect(jsonPath("$.data[0].activityId").value(1L))
-                .andExpect(jsonPath("$.data[0].title").value("Activity 1"))
-                .andExpect(jsonPath("$.data[1].activityId").value(2L))
-                .andExpect(jsonPath("$.data[1].title").value("Activity 2"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.ACTIVITY_NOT_FOUND.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.ACTIVITY_NOT_FOUND.getMessage()))
                 .andDo(MockMvcResultHandlers.print())
                 .andReturn();
 
         System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
     }
 
+    /**
+     * 3-2. 액티비티 업데이트 실패 테스트: 잘못된 입력 데이터 (400 Bad Request)
+     */
     @Test
-    @DisplayName("모든 액티비티를 조회합니다 (인증 사용)")
-    void findAllActivity_ShouldReturn200() throws Exception {
-        // Given
-        List<ActivitySearchResponseDto> mockActivities = List.of(
-                ActivitySearchResponseDto.builder()
-                        .activityId(1L)
-                        .title("Activity 1")
-                        .status(ActivityStatus.PROGRESSING)
-                        .isSubscribed(true)
-                        .place("Seoul")
-                        .currentNumber(5)
-                        .maxNumber(10)
-                        .expiredAt(LocalDateTime.now().plusDays(1))
-                        .build(),
-                ActivitySearchResponseDto.builder()
-                        .activityId(2L)
-                        .title("Activity 2")
-                        .status(ActivityStatus.COMPLETED)
-                        .isSubscribed(false)
-                        .place("Busan")
-                        .currentNumber(10)
-                        .maxNumber(10)
-                        .expiredAt(LocalDateTime.now().plusDays(3))
-                        .build()
-        );
+    @DisplayName("액티비티 업데이트 실패 테스트: 잘못된 입력 데이터 (400 Bad Request)")
+    void updateActivity_WithInvalidInput_ShouldReturn400() throws Exception {
+        // Given: 잘못된 title (빈 문자열)
+        ActivityUpdateRequestDto updateRequestDto = ActivityUpdateRequestDto.builder()
+                .activityId(1L)
+                .title("")  // 유효하지 않은 title
+                .status(ActivityStatus.DONE)
+                .maxNumber(15)
+                .description("Updated description")
+                .place("Busan")
+                .placeUrl("http://updated-example.com")
+                .expiredAt(LocalDateTime.now().plusDays(2))
+                .build();
 
-        Mockito.when(activityService.findAllActivity()).thenReturn(mockActivities);
+        String requestBody = objectMapper.writeValueAsString(updateRequestDto);
 
         // When
-        ResultActions resultActions = mockMvc.perform(get("/api/v1/activity/all")
-                .header("Authorization", "Bearer " + token));
+        ResultActions resultActions = mockMvc.perform(put("/api/v1/activity/update")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        // 예상 응답 메시지: "유효하지 않은 액티비티 요청입니다: title: must not be empty"
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.GENERAL_BAD_REQUEST.getStatusCode()))
+                .andExpect(jsonPath("$.message").value("title: Title must not be blank"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 3-3. 액티비티 업데이트 실패 테스트: 인증 실패 (401 Unauthorized)
+     */
+    @Test
+    @DisplayName("액티비티 업데이트 실패 테스트: 인증 실패 (401 Unauthorized)")
+    void updateActivity_WithInvalidToken_ShouldReturn401() throws Exception {
+        // Given
+        ActivityUpdateRequestDto updateRequestDto = ActivityUpdateRequestDto.builder()
+                .activityId(1L)
+                .title("Updated Activity Title")
+                .status(ActivityStatus.DONE)
+                .maxNumber(15)
+                .description("Updated description")
+                .place("Busan")
+                .placeUrl("http://updated-example.com")
+                .expiredAt(LocalDateTime.now().plusDays(2))
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(updateRequestDto);
+
+        // When: 유효하지 않은 토큰 사용
+        ResultActions resultActions = mockMvc.perform(put("/api/v1/activity/update")
+                .header("Authorization", "Bearer invalid_token")  // 유효하지 않은 토큰
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        // 예상 응답 메시지: "잘못된 쿠키로 접근했습니다!"
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 4. 액티비티 삭제 성공 테스트
+     */
+    @Test
+    @DisplayName("액티비티를 삭제합니다 (인증 사용)")
+    void deleteActivity_ShouldReturn200() throws Exception {
+        // Given
+        ActivityDeleteRequestDto requestDto = ActivityDeleteRequestDto.builder()
+                .activityId(1L)
+                .build();
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(activityService).deleteActivity(Mockito.any(ActivityDeleteRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(delete("/api/v1/activity/delete")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
 
         // Then
         MvcResult mvcResult = resultActions
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_SEARCHED.getStatusCode()))
-                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_SEARCHED.getMessage()))
-                .andExpect(jsonPath("$.data.length()").value(mockActivities.size()))
-                .andExpect(jsonPath("$.data[0].activityId").value(1L))
-                .andExpect(jsonPath("$.data[0].title").value("Activity 1"))
-                .andExpect(jsonPath("$.data[1].activityId").value(2L))
-                .andExpect(jsonPath("$.data[1].title").value("Activity 2"))
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_DELETED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_DELETED.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 4-1. 액티비티 삭제 실패 테스트: 존재하지 않는 ID (404 Not Found)
+     */
+    @Test
+    @DisplayName("액티비티 삭제 실패 테스트: 존재하지 않는 ID (404 Not Found)")
+    void deleteActivity_WithNonExistentId_ShouldReturn404() throws Exception {
+        // Given: 존재하지 않는 액티비티 ID
+        ActivityDeleteRequestDto requestDto = ActivityDeleteRequestDto.builder()
+                .activityId(999L)
+                .build();
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // Mocking the service method to throw exception
+        Mockito.doThrow(new RepositoryException(ExceptionStatus.ACTIVITY_NOT_FOUND))
+                .when(activityService).deleteActivity(Mockito.any(ActivityDeleteRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(delete("/api/v1/activity/delete")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        // 예상 응답 메시지: "액티비티를 찾을 수 없습니다"
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.ACTIVITY_NOT_FOUND.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.ACTIVITY_NOT_FOUND.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 4-2. 액티비티 삭제 실패 테스트: 잘못된 입력 데이터 (400 Bad Request)
+     */
+    @Test
+    @DisplayName("액티비티 삭제 실패 테스트: 잘못된 입력 데이터 (400 Bad Request)")
+    void deleteActivity_WithInvalidInput_ShouldReturn400() throws Exception {
+        // Given: activityId가 null인 경우
+        ActivityDeleteRequestDto requestDto = ActivityDeleteRequestDto.builder()
+                .activityId(null)  // 유효하지 않은 activityId
+                .build();
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(delete("/api/v1/activity/delete")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        // 예상 응답 메시지: "유효하지 않은 액티비티 요청입니다: activityId: must not be null"
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.GENERAL_BAD_REQUEST.getStatusCode()))
+                .andExpect(jsonPath("$.message").value("activityId: ActivityId must not be blank"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 4-3. 액티비티 삭제 실패 테스트: 인증 실패 (401 Unauthorized)
+     */
+    @Test
+    @DisplayName("액티비티 삭제 실패 테스트: 인증 실패 (401 Unauthorized)")
+    void deleteActivity_WithInvalidToken_ShouldReturn401() throws Exception {
+        // Given
+        ActivityDeleteRequestDto requestDto = ActivityDeleteRequestDto.builder()
+                .activityId(1L)
+                .build();
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // When: 유효하지 않은 토큰 사용
+        ResultActions resultActions = mockMvc.perform(delete("/api/v1/activity/delete")
+                .header("Authorization", "Bearer invalid_token")  // 유효하지 않은 토큰
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        // 예상 응답 메시지: "잘못된 쿠키로 접근했습니다!"
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 5. 빌더로 생성한 ActivityUpdateRequestDto로 액티비티 업데이트 실패 테스트: 잘못된 입력 데이터 (400 Bad Request)
+     */
+    // 해당 테스트는 이미 3-2에서 구현되었습니다.
+
+    /**
+     * 5-1. 액티비티 상태별 조회 실패 테스트: 잘못된 상태 값 (400 Bad Request)
+     */
+    @Test
+    @DisplayName("액티비티 상태별 조회 실패 테스트: 잘못된 상태 값 (400 Bad Request)")
+    void findActivityByStatus_WithInvalidStatus_ShouldReturn400() throws Exception {
+        // Given: 존재하지 않는 상태 값
+        String invalidStatus = "INVALID_STATUS";
+
+        // When
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/activity/" + invalidStatus)
+                .header("Authorization", "Bearer " + token));
+
+        // Then
+        // 예상 응답 메시지: "유효하지 않은 액티비티 요청입니다: status: ..." (해당 필드명과 메시지)
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.GENERAL_BAD_REQUEST.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.GENERAL_BAD_REQUEST.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 5-2. 액티비티 상태별 조회 실패 테스트: 인증 실패 (401 Unauthorized)
+     */
+    @Test
+    @DisplayName("액티비티 상태별 조회 실패 테스트: 인증 실패 (401 Unauthorized)")
+    void findActivityByStatus_WithInvalidToken_ShouldReturn401() throws Exception {
+        // Given: 존재하지 않는 상태 값
+        String status = "PROGRESSING";
+
+        // When: 유효하지 않은 토큰 사용
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/activity/" + status)
+                .header("Authorization", "Bearer invalid_token"));
+
+        // Then
+        // 예상 응답 메시지: "잘못된 쿠키로 접근했습니다!"
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 6. 모든 액티비티 조회 실패 테스트: 인증 실패 (401 Unauthorized)
+     */
+    @Test
+    @DisplayName("모든 액티비티 조회 실패 테스트: 인증 실패 (401 Unauthorized)")
+    void findAllActivity_WithInvalidToken_ShouldReturn401() throws Exception {
+        // When: 유효하지 않은 토큰 사용
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/activity/all")
+                .header("Authorization", "Bearer invalid_token"));
+
+        // Then
+        // 예상 응답 메시지: "잘못된 쿠키로 접근했습니다!"
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getMessage()))
                 .andDo(MockMvcResultHandlers.print())
                 .andReturn();
 

--- a/src/test/java/org/clubs/blueheart/activity/api/ActivityHistoryApiTest.java
+++ b/src/test/java/org/clubs/blueheart/activity/api/ActivityHistoryApiTest.java
@@ -1,0 +1,231 @@
+package org.clubs.blueheart.activity.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.clubs.blueheart.activity.application.ActivityHistoryService;
+import org.clubs.blueheart.activity.domain.ActivityStatus;
+import org.clubs.blueheart.activity.dto.request.ActivitySubscribeRequestDto;
+import org.clubs.blueheart.activity.dto.response.ActivitySearchResponseDto;
+import org.clubs.blueheart.user.dto.response.UserInfoResponseDto;
+import org.clubs.blueheart.config.jwt.JwtGenerator;
+import org.clubs.blueheart.response.ResponseStatus;
+import org.clubs.blueheart.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+// 전체 컨텍스트 로딩 & 보안 필터 적용
+@SpringBootTest
+@org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+class ActivityHistoryApiTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtGenerator jwtGenerator;  // 실제 Bean 주입
+
+    @MockBean
+    private ActivityHistoryService activityHistoryService;
+
+    private String token;
+
+    @BeforeEach
+    void setup() {
+        // 테스트 시작 전에 유효한 JWT 토큰 생성
+        token = createLoginJwt(1L, "201234567", "홍길동", UserRole.USER);
+    }
+
+    /**
+     * JwtGenerator를 사용하여 테스트용 JWT 토큰을 생성하는 유틸 메서드
+     */
+    public String createLoginJwt(Long userId, String studentNumber, String username, UserRole role) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("userId", userId);
+        payload.put("studentNumber", studentNumber);
+        payload.put("username", username);
+        payload.put("role", role);
+
+        // 예: 최종 JWT는 1일 유효
+        long finalExpire = 24L * 60 * 60 * 1000;
+
+        return jwtGenerator.createToken(payload, finalExpire);
+    }
+
+    @Test
+    @DisplayName("빌더로 생성한 ActivitySubscribeRequestDto로 액티비티 구독 테스트 (인증 사용)")
+    void subscribeActivity_ShouldReturn200() throws Exception {
+        // Given
+        ActivitySubscribeRequestDto subscribeRequestDto = ActivitySubscribeRequestDto.builder()
+                .activityId(1L)
+                .userId(1L)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(subscribeRequestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(activityHistoryService).subscribeActivity(Mockito.any(ActivitySubscribeRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/activity-history/subscribe")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_HISTORY_SUBSCRIBED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_HISTORY_SUBSCRIBED.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("빌더로 생성한 ActivitySubscribeRequestDto로 액티비티 구독 해지 테스트 (인증 사용)")
+    void unsubscribeActivity_ShouldReturn200() throws Exception {
+        // Given
+        ActivitySubscribeRequestDto unsubscribeRequestDto = ActivitySubscribeRequestDto.builder()
+                .activityId(1L)
+                .userId(1L)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(unsubscribeRequestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(activityHistoryService).unsubscribeActivity(Mockito.any(ActivitySubscribeRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/activity-history/unsubscribe")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_HISTORY_UNSUBSCRIBED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_HISTORY_UNSUBSCRIBED.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("내 활동 이력을 조회합니다 (인증 사용)")
+    void getMyActivityHistoryInfo_ShouldReturn200() throws Exception {
+        // Given
+        Long userId = 1L;
+        List<ActivitySearchResponseDto> mockActivityHistory = List.of(
+                ActivitySearchResponseDto.builder()
+                        .activityId(1L)
+                        .title("Activity 1")
+                        .status(ActivityStatus.PROGRESSING)
+                        .isSubscribed(true)
+                        .place("Seoul")
+                        .currentNumber(5)
+                        .maxNumber(10)
+                        .expiredAt(LocalDateTime.now().plusDays(1))
+                        .build(),
+                ActivitySearchResponseDto.builder()
+                        .activityId(2L)
+                        .title("Activity 2")
+                        .status(ActivityStatus.COMPLETED)
+                        .isSubscribed(false)
+                        .place("Busan")
+                        .currentNumber(10)
+                        .maxNumber(10)
+                        .expiredAt(LocalDateTime.now().plusDays(3))
+                        .build()
+        );
+
+        Mockito.when(activityHistoryService.getMyActivityHistoryInfo(userId)).thenReturn(mockActivityHistory);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/activity-history/me")
+                .header("Authorization", "Bearer " + token));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_SEARCHED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_SEARCHED.getMessage()))
+                .andExpect(jsonPath("$.data.length()").value(mockActivityHistory.size()))
+                .andExpect(jsonPath("$.data[0].activityId").value(1L))
+                .andExpect(jsonPath("$.data[0].title").value("Activity 1"))
+                .andExpect(jsonPath("$.data[1].activityId").value(2L))
+                .andExpect(jsonPath("$.data[1].title").value("Activity 2"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    @Test
+    @DisplayName("특정 활동에 구독한 사용자를 조회합니다 (인증 사용)")
+    void findSubscribedUser_ShouldReturn200() throws Exception {
+        // Given
+        Long activityId = 1L;
+        List<UserInfoResponseDto> mockSubscribedUsers = List.of(
+                UserInfoResponseDto.builder()
+                        .studentNumber("201234568")
+                        .username("사용자1")
+                        .role(UserRole.USER)
+                        .build(),
+                UserInfoResponseDto.builder()
+                        .studentNumber("201234569")
+                        .username("사용자2")
+                        .role(UserRole.USER)
+                        .build()
+        );
+
+        Mockito.when(activityHistoryService.findSubscribedUser(activityId)).thenReturn(mockSubscribedUsers);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/activity-history/" + activityId)
+                .header("Authorization", "Bearer " + token));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.ACTIVITY_SEARCHED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.ACTIVITY_SEARCHED.getMessage()))
+                .andExpect(jsonPath("$.data.length()").value(mockSubscribedUsers.size()))
+                .andExpect(jsonPath("$.data[0].studentNumber").value("201234568"))
+                .andExpect(jsonPath("$.data[0].username").value("사용자1"))
+                .andExpect(jsonPath("$.data[0].role").value("USER"))
+                .andExpect(jsonPath("$.data[1].studentNumber").value("201234569"))
+                .andExpect(jsonPath("$.data[1].username").value("사용자2"))
+                .andExpect(jsonPath("$.data[1].role").value("USER"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+}

--- a/src/test/java/org/clubs/blueheart/activity/api/ActivityHistoryApiTest.java
+++ b/src/test/java/org/clubs/blueheart/activity/api/ActivityHistoryApiTest.java
@@ -2,7 +2,6 @@ package org.clubs.blueheart.activity.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.clubs.blueheart.activity.application.ActivityHistoryService;
-import org.clubs.blueheart.activity.application.ActivityService;
 import org.clubs.blueheart.activity.domain.ActivityStatus;
 import org.clubs.blueheart.activity.dto.request.ActivitySubscribeRequestDto;
 import org.clubs.blueheart.activity.dto.response.ActivitySearchResponseDto;
@@ -19,7 +18,6 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -32,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;

--- a/src/test/java/org/clubs/blueheart/activity/application/ActivityHistoryServiceTest.java
+++ b/src/test/java/org/clubs/blueheart/activity/application/ActivityHistoryServiceTest.java
@@ -1,0 +1,24 @@
+package org.clubs.blueheart.activity.application;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ActivityHistoryServiceTest {
+
+    @Test
+    void subscribeActivity() {
+    }
+
+    @Test
+    void unsubscribeActivity() {
+    }
+
+    @Test
+    void getMyActivityHistoryInfo() {
+    }
+
+    @Test
+    void findSubscribedUser() {
+    }
+}

--- a/src/test/java/org/clubs/blueheart/activity/application/ActivityServiceTest.java
+++ b/src/test/java/org/clubs/blueheart/activity/application/ActivityServiceTest.java
@@ -1,0 +1,32 @@
+package org.clubs.blueheart.activity.application;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ActivityServiceTest {
+
+    @Test
+    void createActivity() {
+    }
+
+    @Test
+    void updateActivity() {
+    }
+
+    @Test
+    void findActivityByStatus() {
+    }
+
+    @Test
+    void findAllActivity() {
+    }
+
+    @Test
+    void findOneActivityDetailById() {
+    }
+
+    @Test
+    void deleteActivity() {
+    }
+}

--- a/src/test/java/org/clubs/blueheart/auth/api/AuthApiTest.java
+++ b/src/test/java/org/clubs/blueheart/auth/api/AuthApiTest.java
@@ -1,0 +1,278 @@
+package org.clubs.blueheart.auth.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.clubs.blueheart.auth.application.AuthService;
+import org.clubs.blueheart.auth.dto.request.AuthInviteAllRequestDto;
+import org.clubs.blueheart.auth.dto.request.AuthInviteOneRequestDto;
+import org.clubs.blueheart.auth.dto.request.AuthLoginRequestDto;
+import org.clubs.blueheart.auth.dto.request.AuthVerifyRequestDto;
+import org.clubs.blueheart.auth.vo.AuthJwtVo;
+import org.clubs.blueheart.response.GlobalResponseHandler;
+import org.clubs.blueheart.response.ResponseStatus;
+import org.clubs.blueheart.user.domain.UserRole;
+import org.clubs.blueheart.user.dto.request.UserInfoRequestDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+public class AuthApiTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    private String token;
+
+    @BeforeEach
+    void setup() {
+        // Mock a valid token (adjust according to your authentication mechanism)
+        token = "mocked-valid-jwt-token";
+    }
+
+    /**
+     * 1. 사용자 등록 테스트
+     */
+    @Test
+    @DisplayName("사용자 등록 성공 테스트 (인증 필요 없음)")
+    void registerUser_ShouldReturn201() throws Exception {
+        // Given
+        UserInfoRequestDto userInfoRequestDto = UserInfoRequestDto.builder()
+                .studentNumber("201234567")
+                .username("홍길동")
+                .role(UserRole.USER)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(userInfoRequestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(authService).registerUser(any(UserInfoRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.AUTH_USER_CREATED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.AUTH_USER_CREATED.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist()) // 데이터 없음
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 2. 사용자 로그인 테스트
+     */
+    @Test
+    @DisplayName("사용자 로그인 성공 테스트 (인증 필요 없음)")
+    void loginUser_ShouldReturn200() throws Exception {
+        // Given
+        AuthLoginRequestDto authLoginRequestDto = AuthLoginRequestDto.builder()
+                .studentNumber("201234567")
+                .username("홍길동")
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(authLoginRequestDto);
+
+        // Mocking the service methods
+        // isSessionValid가 boolean을 반환한다고 가정
+        Mockito.when(authService.isSessionValid(anyString())).thenReturn(true);
+
+        AuthJwtVo mockAuthJwtVo = AuthJwtVo.builder()
+                .id(1L)
+                .studentNumber("201234567")
+                .username("홍길동")
+                .role(UserRole.USER)
+                .build();
+
+        Mockito.when(authService.loginUserByStudentNumberAndUsername(any(AuthLoginRequestDto.class)))
+                .thenReturn(mockAuthJwtVo);
+
+        Mockito.when(authService.createLoginJwt(anyLong(), anyString(), anyString(), any(UserRole.class)))
+                .thenReturn("mocked-jwt-token");
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Set-Cookie"))
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.AUTH_LOGGED_IN.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.AUTH_LOGGED_IN.getMessage()))
+                .andExpect(jsonPath("$.data").value(UserRole.USER.toString()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 3. 사용자 로그아웃 테스트
+     */
+    @Test
+    @DisplayName("사용자 로그아웃 성공 테스트 (인증 필요 없음)")
+    void logoutUser_ShouldReturn200() throws Exception {
+        // Given
+        AuthLoginRequestDto authLoginRequestDto = AuthLoginRequestDto.builder()
+                .studentNumber("201234567")
+                .username("홍길동")
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(authLoginRequestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(authService).logoutUser(any(AuthLoginRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/logout")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.AUTH_LOGGED_OUT.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.AUTH_LOGGED_OUT.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist()) // 데이터 없음
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 4. 전체 사용자 초대 테스트
+     */
+    @Test
+    @DisplayName("전체 사용자 초대 성공 테스트 (인증 필요)")
+    void inviteAllUser_ShouldReturn201() throws Exception {
+        // Given
+        AuthInviteAllRequestDto authInviteAllRequestDto = AuthInviteAllRequestDto.builder()
+                .creatorId(1L)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(authInviteAllRequestDto);
+
+        String mockInviteAllUrl = "http://invite-all.example.com";
+
+        Mockito.when(authService.inviteAllUser(any(AuthInviteAllRequestDto.class)))
+                .thenReturn(mockInviteAllUrl);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/invite/all")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.AUTH_INVITE_LINK_CREATED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.AUTH_INVITE_LINK_CREATED.getMessage()))
+                .andExpect(jsonPath("$.data").value(mockInviteAllUrl))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 5. 특정 사용자 초대 테스트
+     */
+    @Test
+    @DisplayName("특정 사용자 초대 성공 테스트 (인증 필요)")
+    void inviteUserByStudentNumber_ShouldReturn201() throws Exception {
+        // Given
+        AuthInviteOneRequestDto authInviteOneRequestDto = AuthInviteOneRequestDto.builder()
+                .creatorId(1L)
+                .targetStudentNumber("201234568")
+                .targetUsername("홍길동")
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(authInviteOneRequestDto);
+
+        String mockInviteUrl = "http://invite-one.example.com";
+
+        Mockito.when(authService.inviteUserByStudentNumber(any(AuthInviteOneRequestDto.class)))
+                .thenReturn(mockInviteUrl);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/invite")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.AUTH_INVITE_LINK_CREATED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.AUTH_INVITE_LINK_CREATED.getMessage()))
+                .andExpect(jsonPath("$.data").value(mockInviteUrl))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 6. 초대 코드 검증 테스트
+     */
+    @Test
+    @DisplayName("초대 코드 검증 성공 테스트 (인증 필요 없음)")
+    void verifyInviteCode_ShouldReturn200() throws Exception {
+        // Given
+        AuthVerifyRequestDto authVerifyRequestDto = AuthVerifyRequestDto.builder()
+                .code("VALID_INVITE_CODE")
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(authVerifyRequestDto);
+
+        String mockSessionId = "mocked-session-id";
+
+        Mockito.when(authService.verifyInviteCode(any(AuthVerifyRequestDto.class)))
+                .thenReturn(mockSessionId);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(header().exists("Set-Cookie"))
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.AUTH_VERIFIED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.AUTH_VERIFIED.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist()) // 데이터 없음
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(cookie().value("SESSION_ID", mockSessionId));
+    }
+}

--- a/src/test/java/org/clubs/blueheart/auth/api/AuthApiTest.java
+++ b/src/test/java/org/clubs/blueheart/auth/api/AuthApiTest.java
@@ -133,7 +133,7 @@ public class AuthApiTest {
         MvcResult mvcResult = resultActions
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.GENERAL_BAD_REQUEST.getStatusCode()))
-                .andExpect(jsonPath("$.message").value("studentNumber: studentNumber must not be blank; studentNumber: studentNumber must contain only numbers"))
+                .andExpect(jsonPath("$.message").value("studentNumber: Student number must not be blank"))
                 .andDo(MockMvcResultHandlers.print())
                 .andReturn();
 

--- a/src/test/java/org/clubs/blueheart/auth/api/AuthApiTest.java
+++ b/src/test/java/org/clubs/blueheart/auth/api/AuthApiTest.java
@@ -6,8 +6,7 @@ import org.clubs.blueheart.auth.dto.request.AuthInviteAllRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthInviteOneRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthLoginRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthVerifyRequestDto;
-import org.clubs.blueheart.auth.vo.AuthJwtVo;
-import org.clubs.blueheart.response.GlobalResponseHandler;
+import org.clubs.blueheart.auth.dto.response.AuthJwtResponseDto;
 import org.clubs.blueheart.response.ResponseStatus;
 import org.clubs.blueheart.user.domain.UserRole;
 import org.clubs.blueheart.user.dto.request.UserInfoRequestDto;
@@ -19,7 +18,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseCookie;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -103,7 +101,7 @@ public class AuthApiTest {
         // isSessionValid가 boolean을 반환한다고 가정
         Mockito.when(authService.isSessionValid(anyString())).thenReturn(true);
 
-        AuthJwtVo mockAuthJwtVo = AuthJwtVo.builder()
+        AuthJwtResponseDto mockAuthJwtResponseDto = AuthJwtResponseDto.builder()
                 .id(1L)
                 .studentNumber("201234567")
                 .username("홍길동")
@@ -111,7 +109,7 @@ public class AuthApiTest {
                 .build();
 
         Mockito.when(authService.loginUserByStudentNumberAndUsername(any(AuthLoginRequestDto.class)))
-                .thenReturn(mockAuthJwtVo);
+                .thenReturn(mockAuthJwtResponseDto);
 
         Mockito.when(authService.createLoginJwt(anyLong(), anyString(), anyString(), any(UserRole.class)))
                 .thenReturn("mocked-jwt-token");

--- a/src/test/java/org/clubs/blueheart/auth/api/AuthApiTest.java
+++ b/src/test/java/org/clubs/blueheart/auth/api/AuthApiTest.java
@@ -7,6 +7,9 @@ import org.clubs.blueheart.auth.dto.request.AuthInviteOneRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthLoginRequestDto;
 import org.clubs.blueheart.auth.dto.request.AuthVerifyRequestDto;
 import org.clubs.blueheart.auth.dto.response.AuthJwtResponseDto;
+import org.clubs.blueheart.config.jwt.JwtGenerator;
+import org.clubs.blueheart.exception.ExceptionStatus;
+import org.clubs.blueheart.exception.RepositoryException;
 import org.clubs.blueheart.response.ResponseStatus;
 import org.clubs.blueheart.user.domain.UserRole;
 import org.clubs.blueheart.user.dto.request.UserInfoRequestDto;
@@ -23,6 +26,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -43,10 +49,29 @@ public class AuthApiTest {
 
     private String token;
 
+    @Autowired
+    private JwtGenerator jwtGenerator;  // 실제 Bean 주입
+
     @BeforeEach
     void setup() {
-        // Mock a valid token (adjust according to your authentication mechanism)
-        token = "mocked-valid-jwt-token";
+        // 테스트 시작 전에 유효한 JWT 토큰 생성
+        token = createLoginJwt(1L, "201234567", "홍길동", UserRole.USER);
+    }
+
+    /**
+     * JwtProvider를 사용하여 테스트용 JWT 토큰을 생성하는 유틸 메서드
+     */
+    public String createLoginJwt(Long userId, String studentNumber, String username, UserRole role) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("userId", userId);
+        payload.put("studentNumber", studentNumber);
+        payload.put("username", username);
+        payload.put("role", role);
+
+        // 예: 최종 JWT는 1일 유효
+        long finalExpire = 24L * 60 * 60 * 1000;
+
+        return jwtGenerator.createToken(payload, finalExpire);
     }
 
     /**
@@ -83,6 +108,38 @@ public class AuthApiTest {
 
         System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
     }
+
+    /**
+     * 1-1. 사용자 등록 실패 테스트: 잘못된 입력 데이터 (400 Bad Request)
+     */
+    @Test
+    @DisplayName("사용자 등록 실패 테스트: 잘못된 입력 데이터 (400 Bad Request)")
+    void registerUser_WithInvalidInput_ShouldReturn400() throws Exception {
+        // Given: studentNumber가 빈 문자열인 경우
+        UserInfoRequestDto userInfoRequestDto = UserInfoRequestDto.builder()
+                .studentNumber("")  // 유효하지 않은 studentNumber
+                .username("홍길동")
+                .role(UserRole.USER)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(userInfoRequestDto);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.GENERAL_BAD_REQUEST.getStatusCode()))
+                .andExpect(jsonPath("$.message").value("studentNumber: studentNumber must not be blank; studentNumber: studentNumber must contain only numbers"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
 
     /**
      * 2. 사용자 로그인 테스트
@@ -134,10 +191,44 @@ public class AuthApiTest {
     }
 
     /**
+     * 2-1. 사용자 로그인 실패 테스트: 존재하지 않는 사용자 (404 Not Found)
+     */
+    @Test
+    @DisplayName("사용자 로그인 실패 테스트: 존재하지 않는 사용자 (404 Not Found)")
+    void loginUser_NotFound_ShouldReturn404() throws Exception {
+        // Given
+        AuthLoginRequestDto authLoginRequestDto = AuthLoginRequestDto.builder()
+                .studentNumber("201299999")
+                .username("존재하지않음")
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(authLoginRequestDto);
+
+        Mockito.when(authService.loginUserByStudentNumberAndUsername(any(AuthLoginRequestDto.class)))
+                .thenThrow(new RepositoryException(ExceptionStatus.USER_NOT_FOUND_USER));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.USER_NOT_FOUND_USER.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.USER_NOT_FOUND_USER.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+
+    /**
      * 3. 사용자 로그아웃 테스트
      */
     @Test
-    @DisplayName("사용자 로그아웃 성공 테스트 (인증 필요 없음)")
+    @DisplayName("사용자 로그아웃 성공 테스트 (인증 필요)")
     void logoutUser_ShouldReturn200() throws Exception {
         // Given
         AuthLoginRequestDto authLoginRequestDto = AuthLoginRequestDto.builder()
@@ -152,6 +243,7 @@ public class AuthApiTest {
 
         // When
         ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/logout")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody));
 
@@ -166,6 +258,43 @@ public class AuthApiTest {
 
         System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
     }
+
+    /**
+     * 3-1. 사용자 로그아웃 실패 테스트: 존재하지 않는 사용자 (404 Not Found)
+     */
+    @Test
+    @DisplayName("사용자 로그아웃 실패 테스트: 존재하지 않는 사용자 (404 Not Found)")
+    void logoutUser_NotFound_ShouldReturn404() throws Exception {
+        // Given
+        AuthLoginRequestDto authLoginRequestDto = AuthLoginRequestDto.builder()
+                .studentNumber("201299999")
+                .username("존재하지않음")
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(authLoginRequestDto);
+
+        Mockito.doThrow(new RepositoryException(ExceptionStatus.USER_NOT_FOUND_USER))
+                .when(authService).logoutUser(any(AuthLoginRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/logout")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.USER_NOT_FOUND_USER.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.USER_NOT_FOUND_USER.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
 
     /**
      * 4. 전체 사용자 초대 테스트
@@ -202,6 +331,37 @@ public class AuthApiTest {
 
         System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
     }
+
+    /**
+     * 4-1. 전체 사용자 초대 실패 테스트: 인증 실패 (401 Unauthorized)
+     */
+    @Test
+    @DisplayName("전체 사용자 초대 실패 테스트: 인증 실패 (401 Unauthorized)")
+    void inviteAllUser_WithInvalidToken_ShouldReturn401() throws Exception {
+        // Given
+        AuthInviteAllRequestDto authInviteAllRequestDto = AuthInviteAllRequestDto.builder()
+                .creatorId(1L)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(authInviteAllRequestDto);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/invite/all")
+                .header("Authorization", "Bearer invalid_token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
 
     /**
      * 5. 특정 사용자 초대 테스트
@@ -242,6 +402,42 @@ public class AuthApiTest {
     }
 
     /**
+     * 5-1. 특정 사용자 초대 실패 테스트: 존재하지 않는 사용자 (404 Not Found)
+     */
+    @Test
+    @DisplayName("특정 사용자 초대 실패 테스트: 존재하지 않는 사용자 (404 Not Found)")
+    void inviteUserByStudentNumber_NotFound_ShouldReturn404() throws Exception {
+        // Given
+        AuthInviteOneRequestDto authInviteOneRequestDto = AuthInviteOneRequestDto.builder()
+                .creatorId(1L)
+                .targetStudentNumber("201299999")
+                .targetUsername("존재하지않음")
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(authInviteOneRequestDto);
+
+        Mockito.when(authService.inviteUserByStudentNumber(any(AuthInviteOneRequestDto.class)))
+                .thenThrow(new RepositoryException(ExceptionStatus.USER_NOT_FOUND_USER));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/invite")
+                .header("Authorization", "Bearer " + token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.USER_NOT_FOUND_USER.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.USER_NOT_FOUND_USER.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+
+    /**
      * 6. 초대 코드 검증 테스트
      */
     @Test
@@ -274,4 +470,37 @@ public class AuthApiTest {
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(cookie().value("SESSION_ID", mockSessionId));
     }
+
+    /**
+     * 6-1. 초대 코드 검증 실패 테스트: 잘못된 코드 (400 Bad Request)
+     */
+    @Test
+    @DisplayName("초대 코드 검증 실패 테스트: 잘못된 코드 (400 Bad Request)")
+    void verifyInviteCode_WithInvalidCode_ShouldReturn400() throws Exception {
+        // Given
+        AuthVerifyRequestDto authVerifyRequestDto = AuthVerifyRequestDto.builder()
+                .code("INVALID_CODE")
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(authVerifyRequestDto);
+
+        Mockito.when(authService.verifyInviteCode(any(AuthVerifyRequestDto.class)))
+                .thenThrow(new RepositoryException(ExceptionStatus.AUTH_INVALID_INVITE_CODE));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/auth/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.AUTH_INVALID_INVITE_CODE.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ExceptionStatus.AUTH_INVALID_INVITE_CODE.getMessage()))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
 }

--- a/src/test/java/org/clubs/blueheart/auth/api/AuthApiTest.java
+++ b/src/test/java/org/clubs/blueheart/auth/api/AuthApiTest.java
@@ -15,9 +15,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -28,7 +29,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
-@org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+@AutoConfigureMockMvc
 public class AuthApiTest {
 
     @Autowired
@@ -37,7 +38,7 @@ public class AuthApiTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private AuthService authService;
 
     private String token;

--- a/src/test/java/org/clubs/blueheart/group/api/GroupApiTest.java
+++ b/src/test/java/org/clubs/blueheart/group/api/GroupApiTest.java
@@ -31,8 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.any;
-
 /**
  * GroupApi 컨트롤러에 대한 통합 테스트 클래스
  */

--- a/src/test/java/org/clubs/blueheart/group/api/GroupApiTest.java
+++ b/src/test/java/org/clubs/blueheart/group/api/GroupApiTest.java
@@ -133,7 +133,7 @@ class GroupApiTest {
         MvcResult mvcResult = resultActions
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(ExceptionStatus.GENERAL_BAD_REQUEST.getStatusCode()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("userId: UserID must not be null"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("userId: User ID must not be null"))
                 .andDo(MockMvcResultHandlers.print())
                 .andReturn();
 
@@ -268,7 +268,7 @@ class GroupApiTest {
         MvcResult mvcResult = resultActions
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(ExceptionStatus.GENERAL_BAD_REQUEST.getStatusCode()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("groupId: GroupId must not be null"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("groupId: Group ID must not be null"))
                 .andDo(MockMvcResultHandlers.print())
                 .andReturn();
 
@@ -333,7 +333,7 @@ class GroupApiTest {
         MvcResult mvcResult = resultActions
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(ExceptionStatus.GENERAL_BAD_REQUEST.getStatusCode()))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("groupId: GroupId must not be null"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("groupId: Group ID must not be null"))
                 .andDo(MockMvcResultHandlers.print())
                 .andReturn();
 

--- a/src/test/java/org/clubs/blueheart/group/api/GroupApiTest.java
+++ b/src/test/java/org/clubs/blueheart/group/api/GroupApiTest.java
@@ -14,9 +14,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -34,7 +35,7 @@ import static org.mockito.ArgumentMatchers.any;
  * GroupApi 컨트롤러에 대한 통합 테스트 클래스
  */
 @SpringBootTest
-@org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+@AutoConfigureMockMvc
 class GroupApiTest {
 
     @Autowired
@@ -46,7 +47,7 @@ class GroupApiTest {
     @Autowired
     private JwtGenerator jwtGenerator;  // 실제 Bean 주입
 
-    @MockBean
+    @MockitoBean
     private GroupService groupService;
 
     private String token;

--- a/src/test/java/org/clubs/blueheart/group/api/GroupApiTest.java
+++ b/src/test/java/org/clubs/blueheart/group/api/GroupApiTest.java
@@ -1,0 +1,264 @@
+package org.clubs.blueheart.group.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.clubs.blueheart.config.jwt.JwtGenerator;
+import org.clubs.blueheart.group.application.GroupService;
+import org.clubs.blueheart.group.dto.request.GroupInfoRequestDto;
+import org.clubs.blueheart.group.dto.request.GroupUserRequestDto;
+import org.clubs.blueheart.group.dto.response.GroupUserInfoResponseDto;
+import org.clubs.blueheart.response.ResponseStatus;
+import org.clubs.blueheart.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+
+/**
+ * GroupApi 컨트롤러에 대한 통합 테스트 클래스
+ */
+@SpringBootTest
+@org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+class GroupApiTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtGenerator jwtGenerator;  // 실제 Bean 주입
+
+    @MockBean
+    private GroupService groupService;
+
+    private String token;
+
+    @BeforeEach
+    void setup() {
+        // 테스트 시작 전에 유효한 JWT 토큰 생성
+        token = createLoginJwt(1L, "201234567", "홍길동", UserRole.USER);
+    }
+
+    /**
+     * JwtGenerator를 사용하여 테스트용 JWT 토큰을 생성하는 유틸 메서드
+     */
+    public String createLoginJwt(Long userId, String studentNumber, String username, UserRole role) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("userId", userId);
+        payload.put("studentNumber", studentNumber);
+        payload.put("username", username);
+        payload.put("role", role);
+
+        // 예: 최종 JWT는 1일 유효
+        long finalExpire = 24L * 60 * 60 * 1000;
+
+        return jwtGenerator.createToken(payload, finalExpire);
+    }
+
+    /**
+     * 1. 그룹 생성 테스트
+     */
+    @Test
+    @DisplayName("그룹 생성 성공 테스트 (인증 필요)")
+    void createGroup_ShouldReturn201() throws Exception {
+        // Given
+        GroupInfoRequestDto requestDto = GroupInfoRequestDto.builder()
+                .userId(1L)
+                .username("홍길동")
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(groupService).createGroup(ArgumentMatchers.any(GroupInfoRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/group/create")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(ResponseStatus.GROUP_CREATED.getStatusCode()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value(ResponseStatus.GROUP_CREATED.getMessage()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data").doesNotExist()) // 데이터 없음
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 2. 그룹 삭제 테스트
+     */
+    @Test
+    @DisplayName("그룹 삭제 성공 테스트 (인증 필요)")
+    void deleteGroup_ShouldReturn200() throws Exception {
+        // Given
+        GroupInfoRequestDto requestDto = GroupInfoRequestDto.builder()
+                .userId(1L)
+                .username("홍길동")
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(groupService).deleteGroup(ArgumentMatchers.any(GroupInfoRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/group/delete")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(ResponseStatus.GROUP_DELETED.getStatusCode()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value(ResponseStatus.GROUP_DELETED.getMessage()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data").doesNotExist()) // 데이터 없음
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 3. 그룹에 사용자 추가 테스트
+     */
+    @Test
+    @DisplayName("그룹에 사용자 추가 성공 테스트 (인증 필요)")
+    void addGroupUser_ShouldReturn200() throws Exception {
+        // Given
+        GroupUserRequestDto requestDto = GroupUserRequestDto.builder()
+                .groupId(1L)
+                .userId(2L)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(groupService).addGroupUserById(ArgumentMatchers.any(GroupUserRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/group/add")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(ResponseStatus.GROUP_ADD.getStatusCode()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value(ResponseStatus.GROUP_ADD.getMessage()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data").doesNotExist()) // 데이터 없음
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 4. 그룹에서 사용자 제거 테스트
+     */
+    @Test
+    @DisplayName("그룹에서 사용자 제거 성공 테스트 (인증 필요)")
+    void removeGroupUser_ShouldReturn200() throws Exception {
+        // Given
+        GroupUserRequestDto requestDto = GroupUserRequestDto.builder()
+                .groupId(1L)
+                .userId(2L)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(groupService).removeGroupUserById(ArgumentMatchers.any(GroupUserRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/group/remove")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(ResponseStatus.GROUP_REMOVE.getStatusCode()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value(ResponseStatus.GROUP_REMOVE.getMessage()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data").doesNotExist()) // 데이터 없음
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 5. 현재 사용자의 그룹 정보 조회 테스트
+     */
+    @Test
+    @DisplayName("현재 사용자의 그룹 정보 조회 성공 테스트 (인증 필요)")
+    void getMyGroupInfo_ShouldReturn200() throws Exception {
+        // Given
+        List<GroupUserInfoResponseDto> mockGroupInfo = List.of(
+                GroupUserInfoResponseDto.builder()
+                        .userId(1L)
+                        .studentNumber("201234567")
+                        .username("User1")
+                        .role(UserRole.USER)
+                        .build(),
+                GroupUserInfoResponseDto.builder()
+                        .userId(2L)
+                        .studentNumber("201234568")
+                        .username("User2")
+                        .role(UserRole.USER)
+                        .build()
+        );
+
+        Mockito.when(groupService.getMyGroupInfoByUserId(ArgumentMatchers.anyLong()))
+                .thenReturn(mockGroupInfo);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/group/me")
+                .header("Authorization", "Bearer " + token));  // 토큰 첨부
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.statusCode").value(ResponseStatus.GROUP_SEARCHED.getStatusCode()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value(ResponseStatus.GROUP_SEARCHED.getMessage()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.length()").value(mockGroupInfo.size()))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].userId").value(1L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].studentNumber").value("201234567"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].username").value("User1"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].role").value("USER"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].userId").value(2L))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].studentNumber").value("201234568"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].username").value("User2"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].role").value("USER"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+}

--- a/src/test/java/org/clubs/blueheart/notification/api/NotificationApiTest.java
+++ b/src/test/java/org/clubs/blueheart/notification/api/NotificationApiTest.java
@@ -135,7 +135,7 @@ class NotificationApiTest {
         MvcResult mvcResult = resultActions
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.GENERAL_BAD_REQUEST.getStatusCode()))
-                .andExpect(jsonPath("$.message").value("content: 내용은 255자 이하입니다; content: Content must not be blank"))
+                .andExpect(jsonPath("$.message").value("content: Content must not be blank"))
                 .andDo(MockMvcResultHandlers.print())
                 .andReturn();
 
@@ -236,7 +236,7 @@ class NotificationApiTest {
         MvcResult mvcResult = resultActions
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.GENERAL_BAD_REQUEST.getStatusCode()))
-                .andExpect(jsonPath("$.message").value("receiverId: ReceiverID must not be null"))
+                .andExpect(jsonPath("$.message").value("receiverId: Receiver ID must not be null"))
                 .andDo(MockMvcResultHandlers.print())
                 .andReturn();
 

--- a/src/test/java/org/clubs/blueheart/notification/api/NotificationApiTest.java
+++ b/src/test/java/org/clubs/blueheart/notification/api/NotificationApiTest.java
@@ -1,0 +1,189 @@
+package org.clubs.blueheart.notification.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.clubs.blueheart.config.jwt.JwtGenerator;
+import org.clubs.blueheart.notification.application.NotificationService;
+import org.clubs.blueheart.notification.dto.request.NotificationRequestDto;
+import org.clubs.blueheart.notification.dto.response.NotificationResponseDto;
+import org.clubs.blueheart.response.ResponseStatus;
+import org.clubs.blueheart.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * NotificationApi 컨트롤러에 대한 통합 테스트 클래스
+ */
+@SpringBootTest
+@org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+class NotificationApiTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtGenerator jwtGenerator;  // 실제 Bean 주입
+
+    @MockBean
+    private NotificationService notificationService;
+
+    private String token;
+
+    @BeforeEach
+    void setup() {
+        // 테스트 시작 전에 유효한 JWT 토큰 생성
+        token = createLoginJwt(1L, "201234567", "홍길동", UserRole.USER);
+    }
+
+    /**
+     * JwtGenerator를 사용하여 테스트용 JWT 토큰을 생성하는 유틸 메서드
+     */
+    public String createLoginJwt(Long userId, String studentNumber, String username, UserRole role) {
+        return jwtGenerator.createToken(
+                Map.of(
+                        "userId", userId,
+                        "studentNumber", studentNumber,
+                        "username", username,
+                        "role", role.name()
+                ),
+                24L * 60 * 60 * 1000  // 1일 유효
+        );
+    }
+
+    /**
+     * 1. 액티비티에 대한 알림 전송 테스트
+     */
+    @Test
+    @DisplayName("액티비티에 대한 알림 전송 성공 테스트 (인증 필요)")
+    void notificationActivity_ShouldReturn201() throws Exception {
+        // Given
+        NotificationRequestDto requestDto = NotificationRequestDto.builder()
+                .senderId(1L)
+                .receiverId(2L)
+                .content("Hello World1")
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(notificationService).notificationActivity(any(NotificationRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/notification/activity")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.NOTIFICATION_CREATED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.NOTIFICATION_CREATED.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist()) // 데이터 없음
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 2. 그룹에 대한 알림 전송 테스트
+     */
+    @Test
+    @DisplayName("그룹에 대한 알림 전송 성공 테스트 (인증 필요)")
+    void notificationGroup_ShouldReturn201() throws Exception {
+        // Given
+        NotificationRequestDto requestDto = NotificationRequestDto.builder()
+                .senderId(1L)
+                .receiverId(2L)
+                .content("Hello World1")
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(notificationService).notificationGroup(any(NotificationRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/notification/group")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.NOTIFICATION_CREATED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.NOTIFICATION_CREATED.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist()) // 데이터 없음
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 3. 현재 사용자에 대한 모든 알림 조회 테스트
+     */
+    @Test
+    @DisplayName("현재 사용자의 모든 알림 조회 성공 테스트 (인증 필요)")
+    void findAllNotificationMe_ShouldReturn200() throws Exception {
+        // Given
+        List<NotificationResponseDto> mockNotifications = List.of(
+                NotificationResponseDto.builder()
+                        .senderUsername("User 1")
+                        .content("Your group has been updated.")
+                        .createdAt(LocalDateTime.now())
+                        .build(),
+                NotificationResponseDto.builder()
+                        .senderUsername("User 2")
+                        .content("New activity available.")
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+
+        Mockito.when(notificationService.findAllNotificationMe(anyLong()))
+                .thenReturn(mockNotifications);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/notification/me")
+                .header("Authorization", "Bearer " + token));  // 토큰 첨부
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.NOTIFICATION_SEARCHED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.NOTIFICATION_SEARCHED.getMessage()))
+                .andExpect(jsonPath("$.data.length()").value(mockNotifications.size()))
+                .andExpect(jsonPath("$.data[0].senderUsername").value(1L))
+                .andExpect(jsonPath("$.data[0].content").value("Your group has been updated."))
+                .andExpect(jsonPath("$.data[1].senderUsername").value(2L))
+                .andExpect(jsonPath("$.data[1].content").value("New activity available."))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+}

--- a/src/test/java/org/clubs/blueheart/notification/api/NotificationApiTest.java
+++ b/src/test/java/org/clubs/blueheart/notification/api/NotificationApiTest.java
@@ -13,9 +13,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -34,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * NotificationApi 컨트롤러에 대한 통합 테스트 클래스
  */
 @SpringBootTest
-@org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+@AutoConfigureMockMvc
 class NotificationApiTest {
 
     @Autowired
@@ -46,7 +47,7 @@ class NotificationApiTest {
     @Autowired
     private JwtGenerator jwtGenerator;  // 실제 Bean 주입
 
-    @MockBean
+    @MockitoBean
     private NotificationService notificationService;
 
     private String token;

--- a/src/test/java/org/clubs/blueheart/notification/api/NotificationApiTest.java
+++ b/src/test/java/org/clubs/blueheart/notification/api/NotificationApiTest.java
@@ -12,7 +12,6 @@ import org.clubs.blueheart.user.domain.UserRole;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;

--- a/src/test/java/org/clubs/blueheart/user/api/UserApiTest.java
+++ b/src/test/java/org/clubs/blueheart/user/api/UserApiTest.java
@@ -15,13 +15,13 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import java.util.List;
@@ -37,7 +37,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * UserApi 컨트롤러에 대한 통합 테스트 클래스
  */
 @SpringBootTest
-@org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+@AutoConfigureMockMvc
 class UserApiTest {
 
     @Autowired
@@ -49,7 +49,7 @@ class UserApiTest {
     @Autowired
     private JwtGenerator jwtGenerator;  // 실제 Bean 주입
 
-    @MockBean
+    @MockitoBean
     private UserService userService;
 
     private String token;

--- a/src/test/java/org/clubs/blueheart/user/api/UserApiTest.java
+++ b/src/test/java/org/clubs/blueheart/user/api/UserApiTest.java
@@ -28,10 +28,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 

--- a/src/test/java/org/clubs/blueheart/user/api/UserApiTest.java
+++ b/src/test/java/org/clubs/blueheart/user/api/UserApiTest.java
@@ -1,0 +1,4 @@
+package org.clubs.blueheart.user.api;
+
+public class UserApiTest {
+}

--- a/src/test/java/org/clubs/blueheart/user/api/UserApiTest.java
+++ b/src/test/java/org/clubs/blueheart/user/api/UserApiTest.java
@@ -138,7 +138,7 @@ class UserApiTest {
         MvcResult mvcResult = resultActions
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.statusCode").value(ExceptionStatus.GENERAL_BAD_REQUEST.getStatusCode()))
-                .andExpect(jsonPath("$.message").value("studentNumber: must match \"^[0-9]+$\"; studentNumber: studentNumber must not be blank"))
+                .andExpect(jsonPath("$.message").value("studentNumber: Student number must not be blank"))
                 .andDo(MockMvcResultHandlers.print())
                 .andReturn();
 

--- a/src/test/java/org/clubs/blueheart/user/api/UserApiTest.java
+++ b/src/test/java/org/clubs/blueheart/user/api/UserApiTest.java
@@ -1,4 +1,275 @@
 package org.clubs.blueheart.user.api;
 
-public class UserApiTest {
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.clubs.blueheart.config.jwt.JwtGenerator;
+import org.clubs.blueheart.user.application.UserService;
+import org.clubs.blueheart.user.dto.request.UserDeleteRequestDto;
+import org.clubs.blueheart.user.dto.request.UserInfoRequestDto;
+import org.clubs.blueheart.user.dto.request.UserUpdateRequestDto;
+import org.clubs.blueheart.user.dto.response.UserInfoResponseDto;
+import org.clubs.blueheart.response.ResponseStatus;
+import org.clubs.blueheart.user.domain.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * UserApi 컨트롤러에 대한 통합 테스트 클래스
+ */
+@SpringBootTest
+@org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+class UserApiTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JwtGenerator jwtGenerator;  // 실제 Bean 주입
+
+    @MockBean
+    private UserService userService;
+
+    private String token;
+
+    @BeforeEach
+    void setup() {
+        // 테스트 시작 전에 유효한 JWT 토큰 생성
+        token = createLoginJwt(1L, "201234567", "홍길동", UserRole.USER);
+    }
+
+    /**
+     * JwtGenerator를 사용하여 테스트용 JWT 토큰을 생성하는 유틸 메서드
+     */
+    public String createLoginJwt(Long userId, String studentNumber, String username, UserRole role) {
+        return jwtGenerator.createToken(
+                Map.of(
+                        "userId", userId,
+                        "studentNumber", studentNumber,
+                        "username", username,
+                        "role", role.name()
+                ),
+                24L * 60 * 60 * 1000  // 1일 유효
+        );
+    }
+
+    /**
+     * 1. 사용자 생성 테스트
+     */
+    @Test
+    @DisplayName("사용자 생성 성공 테스트 (인증 필요)")
+    void createUser_ShouldReturn201() throws Exception {
+        // Given
+        UserInfoRequestDto requestDto = UserInfoRequestDto.builder()
+                .studentNumber("201234567")
+                .username("홍길동")
+                .role(UserRole.USER)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(userService).createUser(any(UserInfoRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(post("/api/v1/user/create")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.USER_CREATED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.USER_CREATED.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist()) // 데이터 없음
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 2. 사용자 검색 테스트
+     */
+    @Test
+    @DisplayName("키워드로 사용자 검색 성공 테스트 (인증 필요)")
+    void findUserByKeyword_ShouldReturn200() throws Exception {
+        // Given
+        String keyword = "홍";
+
+        List<UserInfoResponseDto> mockUsers = List.of(
+                UserInfoResponseDto.builder()
+                        .studentNumber("201234567")
+                        .username("홍길동")
+                        .role(UserRole.USER)
+                        .build(),
+                UserInfoResponseDto.builder()
+                        .studentNumber("201234568")
+                        .username("홍길순")
+                        .role(UserRole.ADMIN)
+                        .build()
+        );
+
+        Mockito.when(userService.findUserByKeyword(ArgumentMatchers.anyString()))
+                .thenReturn(mockUsers);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/user/search/" + keyword)
+                .header("Authorization", "Bearer " + token));  // 토큰 첨부
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.USER_SEARCHED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.USER_SEARCHED.getMessage()))
+                .andExpect(jsonPath("$.data.length()").value(mockUsers.size()))
+                .andExpect(jsonPath("$.data[0].studentNumber").value("201234567"))
+                .andExpect(jsonPath("$.data[0].username").value("홍길동"))
+                .andExpect(jsonPath("$.data[0].role").value("USER"))
+                .andExpect(jsonPath("$.data[1].studentNumber").value("201234568"))
+                .andExpect(jsonPath("$.data[1].username").value("홍길순"))
+                .andExpect(jsonPath("$.data[1].role").value("ADMIN"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 3. 사용자 정보 업데이트 테스트
+     */
+    @Test
+    @DisplayName("사용자 정보 업데이트 성공 테스트 (인증 필요)")
+    void updateUser_ShouldReturn200() throws Exception {
+        // Given
+        UserUpdateRequestDto updateRequestDto = UserUpdateRequestDto.builder()
+                .userId(1L)
+                .username("홍길동")
+                .studentNumber("201234567")
+                .role(UserRole.ADMIN)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(updateRequestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(userService).updateUserById(any(UserUpdateRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(put("/api/v1/user/update")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.USER_UPDATED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.USER_UPDATED.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist()) // 데이터 없음
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 4. 사용자 삭제 테스트
+     */
+    @Test
+    @DisplayName("사용자 삭제 성공 테스트 (인증 필요)")
+    void deleteUser_ShouldReturn200() throws Exception {
+        // Given
+        UserDeleteRequestDto requestDto = UserDeleteRequestDto.builder()
+                .userId(1L)
+                .build();
+
+        String requestBody = objectMapper.writeValueAsString(requestDto);
+
+        // Mocking the service method
+        Mockito.doNothing().when(userService).deleteUserById(any(UserDeleteRequestDto.class));
+
+        // When
+        ResultActions resultActions = mockMvc.perform(delete("/api/v1/user/delete")
+                .header("Authorization", "Bearer " + token)  // 토큰 첨부
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.USER_DELETED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.USER_DELETED.getMessage()))
+                .andExpect(jsonPath("$.data").doesNotExist()) // 데이터 없음
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
+
+    /**
+     * 5. 모든 사용자 조회 테스트
+     */
+    @Test
+    @DisplayName("모든 사용자 조회 성공 테스트 (인증 필요)")
+    void findAllUser_ShouldReturn200() throws Exception {
+        // Given
+        List<UserInfoResponseDto> mockUsers = List.of(
+                UserInfoResponseDto.builder()
+                        .studentNumber("201234567")
+                        .username("홍길동")
+                        .role(UserRole.USER)
+                        .build(),
+                UserInfoResponseDto.builder()
+                        .studentNumber("201234568")
+                        .username("김철수")
+                        .role(UserRole.ADMIN)
+                        .build()
+        );
+
+        Mockito.when(userService.findAllUser()).thenReturn(mockUsers);
+
+        // When
+        ResultActions resultActions = mockMvc.perform(get("/api/v1/user/all")
+                .header("Authorization", "Bearer " + token));  // 토큰 첨부
+
+        // Then
+        MvcResult mvcResult = resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value(ResponseStatus.USER_SEARCHED.getStatusCode()))
+                .andExpect(jsonPath("$.message").value(ResponseStatus.USER_SEARCHED.getMessage()))
+                .andExpect(jsonPath("$.data.length()").value(mockUsers.size()))
+                .andExpect(jsonPath("$.data[0].studentNumber").value("201234567"))
+                .andExpect(jsonPath("$.data[0].username").value("홍길동"))
+                .andExpect(jsonPath("$.data[0].role").value("USER"))
+                .andExpect(jsonPath("$.data[1].studentNumber").value("201234568"))
+                .andExpect(jsonPath("$.data[1].username").value("김철수"))
+                .andExpect(jsonPath("$.data[1].role").value("ADMIN"))
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        System.out.println("Response: " + mvcResult.getResponse().getContentAsString());
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#14, #27
> ex) #이슈번호, #이슈번호

## 📝작업 내용
- API 레이어 테스트를 위한 코드 작성
- Dto Validation 순서 보장 기능 추가 및 그에 따른 API, Dto 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

